### PR TITLE
Add Andac Entry-Master options

### DIFF
--- a/gui/trading_gui_logic.py
+++ b/gui/trading_gui_logic.py
@@ -10,21 +10,23 @@ TUNING_FILE = "tuning_config.json"
 class TradingGUILogicMixin:
     def apply_recommendations(self):
         try:
-            self.rsi_min.set("40")
-            self.rsi_max.set("80")
-            self.min_volume.set("110")
-            self.volume_avg_period.set("13")
-            self.bigcandle_threshold.set("1.6")
-            self.breakout_lookback.set("12")
-            self.ema_length.set("22")
             self.sl_mode.set("atr")
             self.sl_tp_min_distance.set("4.3")
             self.entry_score_threshold.set("0.7")
             for var in [
-                self.use_rsi_filter, self.use_volume_filter, self.use_volume_boost,
-                self.use_bigcandle_filter, self.use_breakout_filter, self.use_doji_blocker,
-                self.use_engulfing_filter, self.use_ema_filter, self.use_smart_cooldown,
-                self.use_safe_mode
+                self.use_smart_cooldown,
+                self.andac_opt_tpsl,
+                self.andac_opt_rsi_ema,
+                self.andac_opt_safe_mode,
+                self.andac_opt_engulf,
+                self.andac_opt_engulf_bruch,
+                self.andac_opt_engulf_big,
+                self.andac_opt_confirm_delay,
+                self.andac_opt_mtf_confirm,
+                self.andac_opt_volumen_strong,
+                self.andac_opt_session_filter,
+                self.andac_opt_session_bg,
+                self.use_time_filter,
             ]:
                 var.set(True)
             self.log_event("✅ Empfehlungen übernommen")
@@ -34,10 +36,20 @@ class TradingGUILogicMixin:
     def disable_all_filters(self):
         try:
             for var in [
-                self.use_rsi_filter, self.use_volume_filter, self.use_volume_boost,
-                self.use_bigcandle_filter, self.use_breakout_filter, self.use_doji_blocker,
-                self.use_engulfing_filter, self.use_ema_filter, self.use_smart_cooldown,
-                self.use_safe_mode, self.use_time_filter
+                self.use_smart_cooldown,
+                self.andac_opt_tpsl,
+                self.andac_opt_rsi_ema,
+                self.andac_opt_safe_mode,
+                self.andac_opt_engulf,
+                self.andac_opt_engulf_bruch,
+                self.andac_opt_engulf_big,
+                self.andac_opt_confirm_delay,
+                self.andac_opt_mtf_confirm,
+                self.andac_opt_volumen_strong,
+                self.andac_opt_session_filter,
+                self.andac_opt_session_bg,
+                self.use_time_filter,
+                self.use_doji_blocker,
             ]:
                 var.set(False)
             self.log_event("🧹 Alle Filter & Optionen deaktiviert")

--- a/gui_bridge.py
+++ b/gui_bridge.py
@@ -102,23 +102,5 @@ class GUIBridge:
             self.gui.running = False
 
     def update_filter_feedback(self, score):
-        if not self.gui:
-            return
-        try:
-            score = float(score)
-            if score >= 0.9:
-                self.gui.use_breakout_filter.set(True)
-                self.gui.use_volume_boost.set(True)
-                self.gui.breakout_rec_label.config(text="🚀 Boost aktivieren")
-                self.gui.volboost_rec_label.config(text="🚀 Volume Surge aktiv")
-            elif score >= 0.8:
-                self.gui.breakout_rec_label.config(text="🟢 Breakout sinnvoll")
-                self.gui.volboost_rec_label.config(text="🟢 Volumen ok")
-            elif score >= 0.7:
-                self.gui.breakout_rec_label.config(text="🟢 Bestätigung leicht")
-            elif score >= 0.6:
-                self.gui.breakout_rec_label.config(text="🟡 RSI/EMA prüfen")
-            else:
-                self.gui.breakout_rec_label.config(text="🔻 Entry vermeiden")
-        except Exception as e:
-            self.log_event(f"⚠️ Fehler bei Score-Auswertung: {e}")
+        """Placeholder for legacy feedback – no longer used."""
+        return

--- a/main.py
+++ b/main.py
@@ -85,18 +85,19 @@ def bot_control(gui):
                     trade_info = f"{gui.position['side'].upper()} @ {gui.position['entry']}"
                 # Filterstatus
                 filter_status = {
-                    "RSI": (gui.use_rsi_filter.get(), SETTINGS.get("last_rsi_allowed", True)),
-                    "Vol": (gui.use_volume_filter.get(), SETTINGS.get("last_volume_allowed", True)),
-                    "EMA": (gui.use_ema_filter.get(), SETTINGS.get("last_ema_allowed", True)),
-                    "ENG": (gui.use_engulfing_filter.get(), SETTINGS.get("last_engulfing_allowed", True)),
-                    "BIG": (gui.use_bigcandle_filter.get(), SETTINGS.get("last_bigcandle_allowed", True)),
-                    "BRK": (gui.use_breakout_filter.get(), SETTINGS.get("last_breakout_allowed", True)),
-                    "DOJI": (gui.use_doji_blocker.get(), SETTINGS.get("last_doji_allowed", True)),
-                    "T-FLT": (gui.use_time_filter.get(), SETTINGS.get("last_time_allowed", True)),
-                    "SCool": (gui.use_smart_cooldown.get(), True),
+                    "TPSL": gui.andac_opt_tpsl.get(),
+                    "RSI/EMA": gui.andac_opt_rsi_ema.get(),
+                    "SAFE": gui.andac_opt_safe_mode.get(),
+                    "ENG": gui.andac_opt_engulf.get(),
+                    "BRUCH": gui.andac_opt_engulf_bruch.get(),
+                    "BIG": gui.andac_opt_engulf_big.get(),
+                    "DELAY": gui.andac_opt_confirm_delay.get(),
+                    "MTF": gui.andac_opt_mtf_confirm.get(),
+                    "VOL": gui.andac_opt_volumen_strong.get(),
+                    "SES": gui.andac_opt_session_filter.get(),
                 }
-                filter_line = "🎛 Filter: " + " ".join(
-                    f"{k}{'✅' if a and b else '⛔' if a else '❌'}" for k, (a, b) in filter_status.items()
+                filter_line = "🎛 Andac: " + " ".join(
+                    f"{k}{'✅' if v else '❌'}" for k, v in filter_status.items()
                 )
                 status = (
                     f"{farbe} Aktueller PnL: ${pnl:.1f} | Laufzeit: {laufzeit}s | ⏰ {uhrzeit} | 📅 {datum}\n"

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -4,7 +4,6 @@
 # - Integrated console_status utilities for consistent output
 # - Added drawdown limit check via RiskManager
 # - Dynamic stop reason on loop exit
-# - Updated for ``EntryDecision`` dataclass
 # - Fixed max loss check to ignore non-positive limits
 
 import os
@@ -13,7 +12,6 @@ import time
 import traceback
 from datetime import datetime
 
-from signal_engine import SignalEngine
 from data_provider import fetch_latest_candle
 from cooldown_manager import CooldownManager
 from session_filter import SessionFilter
@@ -35,7 +33,7 @@ from init_helpers import import_trader
 from indicator_utils import calculate_ema, calculate_atr
 
 # NEU: Adaptive Engines
-from entry_master_engine import EntryMasterEngine, EntryDecision
+from andac_entry_master import AndacEntryMaster, AndacSignal
 from adaptive_sl_manager import AdaptiveSLManager
 
 from risk_manager import RiskManager
@@ -95,21 +93,6 @@ def run_bot_live(settings=None, app=None):
     global entry_time_global, position_global, ema_trend_global, atr_value_global
     print_info("Debug: Überprüfe die Signalverarbeitung...")
 
-    # Instanziiere die SignalEngine
-    signal_engine = SignalEngine(SETTINGS)
-    
-    # Hole die aktuellen Candle-Daten
-    candle = fetch_latest_candle(SETTINGS["symbol"], SETTINGS["interval"])
-    
-    if candle:
-        signal = signal_engine.evaluate(candle, SETTINGS)  # Jetzt ist candle definiert       
-        if signal:
-            print(f"🚀 Signal: {signal['signal']} | Score: {signal['score']} | RSI: {signal['rsi']} | EMA Trend: {signal['ema_trend']}")
-        else:
-            print("⚠️ Kein Signal gefunden.")
-    else:
-        print("⚠️ Keine Candle-Daten gefunden!")
-
     capital = SETTINGS.get("starting_capital", 1000)
     start_capital = capital
 
@@ -135,13 +118,27 @@ def run_bot_live(settings=None, app=None):
     # interval wird aus GUI übernommen, NICHT überschreiben!
 
     # Restliche Initialisierung...
-    engine = SignalEngine(threshold=settings.get("entry_score_threshold", 0.7))
     cooldown = CooldownManager(settings.get("cooldown", 3))
     smart_cooldown = SmartCooldownManager()
     session_filter = SessionFilter()
 
-    # Adaptive Engines
-    entry_master = EntryMasterEngine(settings, mode="sim" if settings.get("test_mode") else "live")
+    andac_params = {
+        "lookback": int(app.andac_lookback.get()),
+        "puffer": float(app.andac_puffer.get()),
+        "vol_mult": float(app.andac_vol_mult.get()),
+        "opt_tpsl": app.andac_opt_tpsl.get(),
+        "opt_rsi_ema": app.andac_opt_rsi_ema.get(),
+        "opt_safe_mode": app.andac_opt_safe_mode.get(),
+        "opt_engulf": app.andac_opt_engulf.get(),
+        "opt_engulf_bruch": app.andac_opt_engulf_bruch.get(),
+        "opt_engulf_big": app.andac_opt_engulf_big.get(),
+        "opt_confirm_delay": app.andac_opt_confirm_delay.get(),
+        "opt_mtf_confirm": app.andac_opt_mtf_confirm.get(),
+        "opt_volumen_strong": app.andac_opt_volumen_strong.get(),
+        "opt_session_filter": app.andac_opt_session_filter.get(),
+        "opt_session_bg": app.andac_opt_session_bg.get(),
+    }
+    andac_indicator = AndacEntryMaster(**andac_params)
     adaptive_sl = AdaptiveSLManager()
 
     TraderClass = import_trader(settings.get("trading_backend", "sim"))
@@ -208,38 +205,14 @@ def run_bot_live(settings=None, app=None):
             continue  # Weiter zum nächsten Loop
 
         # GUI Empfehlungen/Filter (wie gehabt)
-        if app:
-            try:
-                from filter_recommender import update_filter_recommendations
-                update_filter_recommendations(app, candle)
-            except Exception as e:
-                if "Kerzen für ATR-Berechnung" in str(e):
-                    print("⏳ Sammle Kerzen für ATR-Berechnung...")
-                else:
-                    print("❌ Fehler im Botlauf:", e)
-                    traceback.print_exc()
-                time.sleep(2)
-                print(f"⚠️ Empfehlungssystem konnte nicht geladen werden: {e}")
-
         if hasattr(app, "auto_apply_recommendations") and app.auto_apply_recommendations.get():
             try:
                 app.apply_recommendations()
             except Exception as e:
                 print(f"⚠️ Automatisches Anwenden fehlgeschlagen: {e}")
 
-        # Adaptive Kontext-Vorbereitung
-        context = {
-            "momentum": candle["close"] - candle["open"],
-            "ema": ema if ema is not None else 0,
-            "history": candles[-20:],
-            "support": min(c["low"] for c in candles[-5:]),
-            "resistance": max(c["high"] for c in candles[-5:])
-        }
-
-        # Adaptive Entry Check
-        entry_master.tick()
-        entry_decision: EntryDecision = entry_master.evaluate_entry(candle, context)
-        entry_type = entry_decision.entry_type
+        andac_signal: AndacSignal = andac_indicator.evaluate(candle)
+        entry_type = andac_signal.signal
 
         # --- POSITION HANDLING ---
         if position:
@@ -396,7 +369,7 @@ def run_bot_live(settings=None, app=None):
                 app.live_pnl = 0.0
 
                 if hit_sl:
-                    entry_master.register_sl()
+                    cooldown.register_sl(time.time())
 
                 position = None
                 entry_time_global = None

--- a/status_block.py
+++ b/status_block.py
@@ -30,17 +30,19 @@ def get_entry_status_text(position: dict, capital, app, leverage: int, settings:
 
     # Filterstatus
     filters = {
-        "RSI": app.use_rsi_filter.get(),
-        "Vol": app.use_volume_filter.get(),
-        "EMA": app.use_ema_filter.get(),
-        "ENG": app.use_engulfing_filter.get(),
-        "BIG": app.use_bigcandle_filter.get(),
-        "BRK": app.use_breakout_filter.get(),
-        "DOJI": app.use_doji_blocker.get(),
-        "T-FLT": app.use_time_filter.get(),
+        "TPSL": app.andac_opt_tpsl.get(),
+        "RSI/EMA": app.andac_opt_rsi_ema.get(),
+        "SAFE": app.andac_opt_safe_mode.get(),
+        "ENG": app.andac_opt_engulf.get(),
+        "BRUCH": app.andac_opt_engulf_bruch.get(),
+        "BIG": app.andac_opt_engulf_big.get(),
+        "DELAY": app.andac_opt_confirm_delay.get(),
+        "MTF": app.andac_opt_mtf_confirm.get(),
+        "VOL": app.andac_opt_volumen_strong.get(),
+        "SES": app.andac_opt_session_filter.get(),
         "SCool": app.use_smart_cooldown.get(),
     }
-    filter_line = "🎛 Filter: " + "  ".join(f"{k}{'✅' if v else '❌'}" for k, v in filters.items())
+    filter_line = "🎛 Andac: " + "  ".join(f"{k}{'✅' if v else '❌'}" for k, v in filters.items())
 
     # SmartCooldown-Anzeige
     scool_line = ""


### PR DESCRIPTION
## Summary
- integrate Andac Entry‑Master indicator and expose all options in new GUI column
- drop old indicator checkboxes and related logic
- adapt runtime to use `AndacEntryMaster` for signals
- simplify filter feedback hooks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68718d112fcc832a94ad62821d62734f