### PR TITLE
Add auto recommender and monitor

### DIFF
--- a/auto_recommender.py
+++ b/auto_recommender.py
@@ -1,0 +1,44 @@
+"""Threaded helper that periodically adjusts GUI settings."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Optional
+
+
+class AutoRecommender:
+    """Apply dynamic filter recommendations while the bot is running."""
+
+    def __init__(self, gui, interval: int = 10) -> None:
+        self.gui = gui
+        self.interval = interval
+        self._thread: Optional[threading.Thread] = None
+        self._running = False
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._running = True
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._running = False
+        if self._thread:
+            self._thread.join(timeout=1)
+            self._thread = None
+
+    def _run(self) -> None:
+        while self._running:
+            if (
+                getattr(self.gui, "running", False)
+                and hasattr(self.gui, "auto_apply_recommendations")
+                and self.gui.auto_apply_recommendations.get()
+            ):
+                try:
+                    self.gui.apply_recommendations()
+                except Exception as exc:
+                    if hasattr(self.gui, "log_event"):
+                        self.gui.log_event(f"⚠️ Auto-Empfehlung Fehler: {exc}")
+            time.sleep(self.interval)

--- a/main.py
+++ b/main.py
@@ -12,6 +12,8 @@ from colorama import Fore, Style, init
 from config import SETTINGS
 from exchange_manager import detect_available_exchanges
 from credential_checker import check_all_credentials
+from auto_recommender import AutoRecommender
+from system_monitor import SystemMonitor
 from gui import (
     TradingGUI,
     TradingGUILogicMixin,
@@ -135,6 +137,12 @@ def main():
     gui = EntryMasterGUI(root, cred_manager=cred_manager)
     gui_bridge = GUIBridge(gui_instance=gui)
     gui.callback = lambda: on_gui_start(gui)
+
+    gui.auto_recommender = AutoRecommender(gui)
+    gui.auto_recommender.start()
+    gui.system_monitor = SystemMonitor(gui)
+    gui.system_monitor.start()
+
     threading.Thread(target=bot_control, args=(gui,), daemon=True).start()
     root.mainloop()
 

--- a/system_monitor.py
+++ b/system_monitor.py
@@ -1,0 +1,85 @@
+"""Real-time system monitoring and auto-pause utilities."""
+
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime
+from typing import Optional
+
+from config import SETTINGS
+from credential_checker import check_all_credentials
+from data_provider import fetch_latest_candle
+
+
+def _beep() -> None:
+    """Trigger a simple beep sound in the console."""
+    try:
+        print("\a", end="", flush=True)
+    except Exception:
+        pass
+
+
+class SystemMonitor:
+    """Background watchdog for API and market data integrity."""
+
+    def __init__(self, gui, interval: int = 15) -> None:
+        self.gui = gui
+        self.interval = interval
+        self._thread: Optional[threading.Thread] = None
+        self._running = False
+        self._last_candle_ts: Optional[int] = None
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._running = True
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._running = False
+        if self._thread:
+            self._thread.join(timeout=1)
+            self._thread = None
+
+    # ---- Internals -----------------------------------------------------
+    def _log(self, msg: str) -> None:
+        stamp = datetime.now().strftime("[%H:%M:%S]")
+        full = f"{stamp} {msg}"
+        if hasattr(self.gui, "log_event"):
+            self.gui.log_event(full)
+        else:
+            print(full)
+
+    def _run(self) -> None:
+        while self._running:
+            if not getattr(self.gui, "running", False):
+                time.sleep(1)
+                continue
+            try:
+                creds = check_all_credentials(SETTINGS)
+                if not creds.get("live"):
+                    _beep()
+                    self._log("API nicht erreichbar – Bot pausiert")
+                    self.gui.running = False
+                    continue
+
+                candle = fetch_latest_candle(SETTINGS.get("symbol", "BTCUSDT"), SETTINGS.get("interval", "1m"))
+                if not candle:
+                    _beep()
+                    self._log("Keine Marktdaten empfangen – Bot pausiert")
+                    self.gui.running = False
+                    continue
+                ts = candle.get("timestamp")
+                if ts == self._last_candle_ts:
+                    _beep()
+                    self._log("Marktdaten aktualisieren sich nicht – Bot pausiert")
+                    self.gui.running = False
+                    continue
+                self._last_candle_ts = ts
+            except Exception as exc:
+                _beep()
+                self._log(f"Systemmonitor Fehler: {exc}")
+                self.gui.running = False
+            time.sleep(self.interval)


### PR DESCRIPTION
## Summary
- implement `AutoRecommender` for continuous filter tuning
- add `SystemMonitor` watchdog that checks APIs and market data
- start both threads in main GUI setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871bd6de630832ab8a2e06d7b951b32