### PR TITLE
Add feed monitor with auto pause/resume

### DIFF
--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -101,6 +101,9 @@ class TradingGUI(TradingGUILogicMixin):
         self.feed_status_var = tk.StringVar(value="Feed ❌")
         self.api_status_label = None
         self.feed_status_label = None
+        # Track current connection states for the watchdog
+        self.feed_ok = False
+        self.api_ok = False
 
     def _build_gui(self):
         # --- Oberer Info-Bereich ---

--- a/gui/trading_gui_logic.py
+++ b/gui/trading_gui_logic.py
@@ -174,6 +174,7 @@ class TradingGUILogicMixin:
             self.api_status_var.set(text)
         if hasattr(self, "api_status_label"):
             self.api_status_label.config(foreground=color)
+        self.api_ok = ok
 
     def update_feed_status(self, ok: bool) -> None:
         color = "green" if ok else "red"
@@ -182,6 +183,7 @@ class TradingGUILogicMixin:
             self.feed_status_var.set(text)
         if hasattr(self, "feed_status_label"):
             self.feed_status_label.config(foreground=color)
+        self.feed_ok = ok
 
     def update_pnl(self, pnl):
         self.log_event(f"💰 Trade abgeschlossen: PnL {pnl:.2f} $")

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -158,8 +158,15 @@ def run_bot_live(settings=None, app=None):
     last_printed_price = None
 
     no_signal_printed = False
+    first_feed = False
 
-    while app.running and capital > 0:
+    while capital > 0 and not getattr(app, "force_exit", False):
+        if not getattr(app, "running", False):
+            time.sleep(1)
+            continue
+        if not getattr(app, "feed_ok", True):
+            time.sleep(1)
+            continue
         risk_manager.update_capital(capital)
         # --- Schutzmechanismen ---
         if risk_manager.check_loss_limit() or risk_manager.check_drawdown_limit():
@@ -172,6 +179,11 @@ def run_bot_live(settings=None, app=None):
                 print("⚠️ Keine Candle-Daten.")
                 time.sleep(1)
                 continue
+
+            if not first_feed:
+                first_feed = True
+                if hasattr(app, "log_event"):
+                    app.log_event("✅ Erster Marktdaten-Feed empfangen")
 
             candles.append(candle)
             if len(candles) > 100:

--- a/system_monitor.py
+++ b/system_monitor.py
@@ -1,10 +1,11 @@
 """Real-time system monitoring with auto-pause/resume.
 
 This watchdog checks exchange connectivity and incoming market data every
-few seconds.  If no fresh candles arrive within ``timeout`` seconds the bot
-is automatically paused and the GUI status switches to ``❌``.  As soon as the
-feed recovers the bot resumes trading and the status changes back to ``✅``.
-The logic is exchange agnostic and works for all supported backends.
+few seconds for the **active market only**.  Short interruptions are tolerated
+(``timeout`` defaults to 10s).  If no fresh candle is received within this
+period the bot is paused, an acoustic signal is emitted and the GUI status
+switches to ``❌``.  As soon as a new candle arrives the bot resumes and the
+status changes back to ``✅``.
 """
 
 from __future__ import annotations
@@ -30,12 +31,12 @@ def _beep() -> None:
 class SystemMonitor:
     """Background watchdog for API and market data integrity."""
 
-    def __init__(self, gui, interval: int = 2, timeout: int = 8) -> None:
-        """Create monitor with *interval* seconds and feed *timeout*.
+    def __init__(self, gui, interval: int = 2, timeout: int = 10) -> None:
+        """Create monitor with *interval* seconds and feed ``timeout``.
 
         ``interval`` controls how often the APIs are polled.  If no candle
-        update happens within ``timeout`` seconds the bot will be paused
-        automatically.
+        update happens within ``timeout`` seconds (default ``10``) the bot will
+        be paused automatically.
         """
         self.gui = gui
         self.interval = max(1, interval)

--- a/tests/test_system_monitor.py
+++ b/tests/test_system_monitor.py
@@ -1,0 +1,34 @@
+import unittest
+from system_monitor import SystemMonitor
+
+class DummyGUI:
+    def __init__(self):
+        self.running = True
+        self.feed_status = None
+
+    def update_feed_status(self, ok: bool) -> None:
+        self.feed_status = ok
+
+    def update_api_status(self, ok: bool) -> None:
+        pass
+
+    def log_event(self, msg: str) -> None:
+        pass
+
+class SystemMonitorStateTest(unittest.TestCase):
+    def test_pause_and_resume(self):
+        gui = DummyGUI()
+        mon = SystemMonitor(gui)
+        # simulate feed loss
+        mon._handle_feed_down("lost")
+        self.assertFalse(gui.running)
+        self.assertFalse(mon._feed_ok)
+        self.assertEqual(gui.feed_status, False)
+        # restore feed
+        mon._handle_feed_up()
+        self.assertTrue(gui.running)
+        self.assertTrue(mon._feed_ok)
+        self.assertEqual(gui.feed_status, True)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- track feed/api status in the GUI and expose flags
- improve `SystemMonitor` docs and default timeout
- support pausing/resuming in `run_bot_live`
- log once when the first candle arrives
- test feed pause/resume logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871c67243b8832a80d8f29a1c40a728