### PR TITLE
Fix MEXC/BitMEX price feeds

### DIFF
--- a/andac_entry_master.py
+++ b/andac_entry_master.py
@@ -114,7 +114,7 @@ class AndacEntryMaster:
         return max(0.0, min(100.0, rsi))
 
     # ---- Kernlogik -------------------------------------------------------
-    def evaluate(self, candle: Dict[str, float], symbol: str = "BTCUSDT") -> AndacSignal:
+    def evaluate(self, candle: Dict[str, float], symbol: str = "BTC_USDT") -> AndacSignal:
         """Analysiert die übergebene Kerze und gibt ggf. ein Entry-Signal zurück."""
 
         self.candles.append(candle)

--- a/bitmex_trader.py
+++ b/bitmex_trader.py
@@ -22,6 +22,18 @@ class BitmexTrader(ExchangeAdapter):
         })
         logging.info("BitMEX Trader initialisiert")
 
+    def get_market_price(self, symbol: str = "XBTUSD") -> Optional[float]:
+        """Return the latest market price for *symbol*."""
+        try:
+            url = f"{self.base_url}/instrument?symbol={symbol}"
+            resp = self.session.get(url, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+            return float(data[0]["lastPrice"])
+        except Exception as exc:
+            logging.error("BitMEX Preisabruf fehlgeschlagen: %s", exc)
+            return None
+
     def _get(self, path: str, **params: Any) -> Dict[str, Any]:
         try:
             url = f"{self.base_url}{path}"

--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 # config.py
 
 SETTINGS = {
-    "symbol": "BTCUSDT",
+    "symbol": "BTC_USDT",
     "interval": "1m",
     "starting_balance": 1000,
     "leverage": 20,

--- a/entry_handler.py
+++ b/entry_handler.py
@@ -79,7 +79,7 @@ def handle_entry(
         # Statusobjekt zurückgeben
         position = {
             "active": True,
-            "symbol": settings.get("symbol", "BTCUSDT"),
+            "symbol": settings.get("symbol", "BTC_USDT"),
             "side": direction.upper(),
             "entry_price": entry_price,
             "stop_loss": stop_loss,

--- a/init_helpers.py
+++ b/init_helpers.py
@@ -46,5 +46,5 @@ def calculate_ema(values, length):
 
 
 def normalize_symbol(symbol):
-    """🔤 Entfernt Sonderzeichen aus Symbolnamen, z. B. BTC/USDT → BTCUSDT."""
+    """🔤 Entfernt Sonderzeichen aus Symbolnamen, z. B. BTC/USDT → BTC_USDT."""
     return symbol.replace("/", "").upper()

--- a/paper_trading/engine.py
+++ b/paper_trading/engine.py
@@ -41,7 +41,7 @@ class PaperTradingEngine:
 
     def __init__(
         self,
-        symbol: str = "BTCUSDT",
+        symbol: str = "BTC_USDT",
         leverage: int = 20,
         balance: float = 1000.0,
         db_path: str = "trades.sqlite",

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -12,7 +12,7 @@ import time
 import traceback
 from datetime import datetime
 
-from data_provider import fetch_latest_candle
+from data_provider import fetch_latest_candle, fetch_last_price
 from cooldown_manager import CooldownManager
 from session_filter import SessionFilter
 from status_block import print_entry_status
@@ -174,6 +174,7 @@ def run_bot_live(settings=None, app=None):
 
         try:
             candle = fetch_latest_candle(settings["symbol"], interval)
+            fetch_last_price(settings.get("trading_backend", "mexc"))
             if not candle:
                 print("⚠️ Keine Candle-Daten.")
                 time.sleep(1)


### PR DESCRIPTION
## Summary
- correct default symbol to `BTC_USDT`
- add exchange price mapping and parsing helpers
- update MEXC/BitMEX trader endpoints
- log market data retrieval in realtime runner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871cc6b417c832a9995254a687acb42