### PR TITLE
Consolidate status checks

### DIFF
--- a/gui/api_credential_frame.py
+++ b/gui/api_credential_frame.py
@@ -1,7 +1,7 @@
 import tkinter as tk
 from tkinter import ttk, messagebox
 from api_key_manager import APICredentialManager
-from credential_checker import check_exchange_credentials, check_all_credentials
+from credential_checker import check_exchange_credentials
 from config import SETTINGS
 
 EXCHANGES = ["MEXC", "dYdX", "Binance", "Bybit", "BitMEX"]
@@ -90,9 +90,6 @@ class APICredentialFrame(ttk.LabelFrame):
 
         # Status für GUI anzeigen
         self.status_var.set("aktiv" if ok else f"Fehler: {msg}")
-
-        # always re-check all credentials and show status
-        check_all_credentials(SETTINGS)
 
     def _err(self, msg: str) -> None:
         if self.log_callback:

--- a/main.py
+++ b/main.py
@@ -11,7 +11,6 @@ from colorama import Fore, Style, init
 
 from config import SETTINGS
 from exchange_manager import detect_available_exchanges
-from credential_checker import check_all_credentials
 from auto_recommender import AutoRecommender
 from system_monitor import SystemMonitor
 from gui import (
@@ -46,7 +45,6 @@ def bot_control(gui):
         if cmd == "start":
             if not gui.running:
                 load_settings_from_file()
-                check_all_credentials(SETTINGS)
                 print("🚀 Bot gestartet: TEST-MODUS" if SETTINGS.get("test_mode") else "🚀 Bot gestartet: LIVE-MODUS")
                 gui.running = True
                 threading.Thread(target=run_bot_live, args=(SETTINGS, gui), daemon=True).start()
@@ -122,7 +120,6 @@ def on_gui_start(gui):
         print("⚠️ Bot läuft bereits (GUI-Schutz)")
         return
     load_settings_from_file()
-    check_all_credentials(SETTINGS)
     SETTINGS["interval"] = gui.interval.get()
     print("🚀 Bot gestartet: TEST-MODUS" if SETTINGS.get("test_mode") else "🚀 Bot gestartet: LIVE-MODUS")
     gui.running = True
@@ -131,7 +128,6 @@ def on_gui_start(gui):
 def main():
     load_settings_from_file()
     detect_available_exchanges(SETTINGS)
-    check_all_credentials(SETTINGS)
     root = tk.Tk()
     cred_manager = APICredentialManager()
     gui = EntryMasterGUI(root, cred_manager=cred_manager)

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -363,18 +363,6 @@ def run_bot_live(settings=None, app=None):
                 app.log_event(log_msg)
                 print(f"💰 Aktuelles Balance (Sim): ${capital:.2f}")
 
-                # Verlust-Limit/Auto-Pause
-                if hasattr(app, "max_loss_enabled") and app.max_loss_enabled.get():
-                    try:
-                        max_loss = float(app.max_loss_value.get())
-                        if max_loss > 0 and capital <= (start_capital - max_loss):
-                            app.max_loss_status_label.config(text="Handel gestoppt: Max. Verlust erreicht!", foreground="red")
-                            app.running = False
-                            if hasattr(app, "log_event"):
-                                app.log_event("🛑 Handel gestoppt: Maximaler Verlust erreicht! Manuelles Neustarten erforderlich.")
-                    except Exception as e:
-                        print("❌ Fehler bei Verlust-Limit/Auto-Pause:", e)
-
                 app.update_live_trade_pnl(0.0)
                 app.live_pnl = 0.0
 


### PR DESCRIPTION
## Summary
- remove GUI credential revalidation call
- avoid redundant API checks in main entrypoints
- drop second max loss check in realtime runner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871cf743790832ab9de691293dde265