### PR TITLE
Improve status monitor and callbacks

### DIFF
--- a/gui/api_credential_frame.py
+++ b/gui/api_credential_frame.py
@@ -9,10 +9,12 @@ EXCHANGES = ["MEXC", "dYdX", "Binance", "Bybit", "BitMEX"]
 class APICredentialFrame(ttk.LabelFrame):
     """GUI-Frame zur Eingabe von API-Zugangsdaten."""
 
-    def __init__(self, master: tk.Misc, cred_manager: APICredentialManager, log_callback=None) -> None:
+    def __init__(self, master: tk.Misc, cred_manager: APICredentialManager, log_callback=None, monitor=None) -> None:
         super().__init__(master, text="Exchange API")
         self.cred_manager = cred_manager
         self.log_callback = log_callback
+        # optionaler SystemMonitor für Sofort-Checks
+        self.monitor = monitor
 
         ttk.Label(self, text="Börse:").grid(row=0, column=0, sticky="w")
         self.exchange_var = tk.StringVar(value=EXCHANGES[0])
@@ -90,6 +92,13 @@ class APICredentialFrame(ttk.LabelFrame):
 
         # Status für GUI anzeigen
         self.status_var.set("aktiv" if ok else f"Fehler: {msg}")
+
+        # Sofortige Status-Prüfung auslösen
+        if ok and self.monitor:
+            try:
+                self.monitor.force_check()
+            except Exception:
+                pass
 
     def _err(self, msg: str) -> None:
         if self.log_callback:

--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -287,7 +287,8 @@ class TradingGUI(TradingGUILogicMixin):
             ttk.Entry(parent, textvariable=var).pack()
 
     def _build_api_credentials(self, parent):
-        self.api_frame = APICredentialFrame(parent, self.cred_manager, log_callback=self.log_event)
+        monitor = getattr(self, "system_monitor", None)
+        self.api_frame = APICredentialFrame(parent, self.cred_manager, log_callback=self.log_event, monitor=monitor)
         self.api_frame.pack(pady=(0, 10), fill="x")
 
         status_frame = ttk.Frame(parent)

--- a/main.py
+++ b/main.py
@@ -137,6 +137,7 @@ def main():
     gui.auto_recommender = AutoRecommender(gui)
     gui.auto_recommender.start()
     gui.system_monitor = SystemMonitor(gui)
+    gui.api_frame.monitor = gui.system_monitor
     gui.system_monitor.start()
 
     threading.Thread(target=bot_control, args=(gui,), daemon=True).start()

--- a/tests/test_system_monitor.py
+++ b/tests/test_system_monitor.py
@@ -30,5 +30,20 @@ class SystemMonitorStateTest(unittest.TestCase):
         self.assertTrue(mon._feed_ok)
         self.assertEqual(gui.feed_status, True)
 
+    def test_callbacks(self):
+        gui = DummyGUI()
+        mon = SystemMonitor(gui)
+        events = []
+
+        def cb(kind, state):
+            events.append((kind, state))
+
+        mon.register_callback(cb)
+        mon._handle_api_down()
+        mon._handle_api_up()
+        self.assertIn(("api", False), events)
+        self.assertIn(("api", True), events)
+        mon.unregister_callback(cb)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow `APICredentialFrame` to trigger a status check via `SystemMonitor`
- pass `SystemMonitor` to the API frame
- centralize monitoring with callbacks in `SystemMonitor`
- provide immediate log message when API recovers
- test callback registration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871d644e564832aa664377a48127e1b