### PR TITLE
Implement central status event system

### DIFF
--- a/gui/api_credential_frame.py
+++ b/gui/api_credential_frame.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk, messagebox
 from api_key_manager import APICredentialManager
 from credential_checker import check_exchange_credentials
+from status_events import StatusDispatcher
 from config import SETTINGS
 
 EXCHANGES = ["MEXC", "dYdX", "Binance", "Bybit", "BitMEX"]
@@ -88,6 +89,8 @@ class APICredentialFrame(ttk.LabelFrame):
         else:
             messagebox.showinfo("Status", msg)
 
+        StatusDispatcher.dispatch("api", ok, None if ok else msg)
+
         # Status für GUI anzeigen
         self.status_var.set("aktiv" if ok else f"Fehler: {msg}")
 
@@ -98,3 +101,4 @@ class APICredentialFrame(ttk.LabelFrame):
             messagebox.showwarning("Fehler", msg)
         # Status aktualisieren
         self.status_var.set(f"Fehler: {msg}")
+        StatusDispatcher.dispatch("api", False, msg)

--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from .trading_gui_logic import TradingGUILogicMixin
 from .api_credential_frame import APICredentialFrame, EXCHANGES
 from api_key_manager import APICredentialManager
+from status_events import StatusDispatcher
 
 class TradingGUI(TradingGUILogicMixin):
     def __init__(self, root, cred_manager: APICredentialManager | None = None):
@@ -46,6 +47,8 @@ class TradingGUI(TradingGUILogicMixin):
         self._build_gui()
         self._collect_setting_vars()
         self._build_status_panel()
+        StatusDispatcher.on_api_status(self.update_api_status)
+        StatusDispatcher.on_feed_status(self.update_feed_status)
 
     def _init_variables(self):
         self.multiplier_var = tk.StringVar(value="20")

--- a/status_events.py
+++ b/status_events.py
@@ -1,0 +1,29 @@
+from typing import Callable, Dict, List, Optional
+
+class StatusDispatcher:
+    """Simple event dispatcher for API/feed status changes."""
+
+    _subs: Dict[str, List[Callable[[bool, Optional[str]], None]]] = {
+        "api": [],
+        "feed": [],
+    }
+
+    @classmethod
+    def subscribe(cls, event: str, func: Callable[[bool, Optional[str]], None]) -> None:
+        cls._subs.setdefault(event, []).append(func)
+
+    @classmethod
+    def on_api_status(cls, func: Callable[[bool, Optional[str]], None]) -> None:
+        cls.subscribe("api", func)
+
+    @classmethod
+    def on_feed_status(cls, func: Callable[[bool, Optional[str]], None]) -> None:
+        cls.subscribe("feed", func)
+
+    @classmethod
+    def dispatch(cls, event: str, ok: bool, reason: Optional[str] = None) -> None:
+        for cb in cls._subs.get(event, []):
+            try:
+                cb(ok, reason)
+            except Exception:
+                pass

--- a/system_monitor.py
+++ b/system_monitor.py
@@ -17,6 +17,7 @@ from typing import Optional
 
 from config import SETTINGS
 from credential_checker import check_all_credentials
+from status_events import StatusDispatcher
 import global_state
 
 DISPLAY_NAMES = {
@@ -65,6 +66,8 @@ class SystemMonitor:
             self.gui.update_api_status(True)
         if hasattr(self.gui, "update_feed_status"):
             self.gui.update_feed_status(True)
+        StatusDispatcher.dispatch("api", True)
+        StatusDispatcher.dispatch("feed", True)
         self._running = True
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
@@ -121,6 +124,7 @@ class SystemMonitor:
             self._log(f"{reason} – Bot pausiert")
             if hasattr(self.gui, "update_api_status"):
                 self.gui.update_api_status(False, reason)
+            StatusDispatcher.dispatch("api", False, reason)
             if getattr(self.gui, "running", False):
                 self.gui.running = False
                 self._pause_reason = "api"
@@ -130,12 +134,14 @@ class SystemMonitor:
         if not self._api_ok:
             if hasattr(self.gui, "update_api_status"):
                 self.gui.update_api_status(True)
+            StatusDispatcher.dispatch("api", True)
             if not getattr(self.gui, "running", False) and self._pause_reason == "api":
                 self.gui.running = True
             self._pause_reason = None
         else:
             if hasattr(self.gui, "update_api_status"):
                 self.gui.update_api_status(True)
+            StatusDispatcher.dispatch("api", True)
         self._api_ok = True
 
     def _handle_feed_down(self, reason: str) -> None:
@@ -144,6 +150,7 @@ class SystemMonitor:
             self._log(f"{reason} – Bot pausiert")
             if hasattr(self.gui, "update_feed_status"):
                 self.gui.update_feed_status(False, reason)
+            StatusDispatcher.dispatch("feed", False, reason)
             if getattr(self.gui, "running", False):
                 self.gui.running = False
                 self._pause_reason = "feed"
@@ -153,10 +160,12 @@ class SystemMonitor:
         if not self._feed_ok:
             if hasattr(self.gui, "update_feed_status"):
                 self.gui.update_feed_status(True)
+            StatusDispatcher.dispatch("feed", True)
             if not getattr(self.gui, "running", False) and self._pause_reason == "feed":
                 self.gui.running = True
             self._pause_reason = None
         else:
             if hasattr(self.gui, "update_feed_status"):
                 self.gui.update_feed_status(True)
+            StatusDispatcher.dispatch("feed", True)
         self._feed_ok = True

--- a/tests/test_status_events.py
+++ b/tests/test_status_events.py
@@ -1,0 +1,28 @@
+import unittest
+from status_events import StatusDispatcher
+from system_monitor import SystemMonitor
+
+class DummyGUI:
+    def __init__(self):
+        self.running = True
+    def update_feed_status(self, ok: bool, reason=None):
+        pass
+    def update_api_status(self, ok: bool, reason=None):
+        pass
+    def log_event(self, msg: str):
+        pass
+
+class DispatcherTest(unittest.TestCase):
+    def test_feed_callbacks(self):
+        gui = DummyGUI()
+        mon = SystemMonitor(gui)
+        events = []
+        StatusDispatcher._subs['feed'].clear()
+        StatusDispatcher.on_feed_status(lambda ok, r=None: events.append((ok, r)))
+        mon._handle_feed_down('err')
+        self.assertEqual(events[-1], (False, 'err'))
+        mon._handle_feed_up()
+        self.assertEqual(events[-1], (True, None))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `status_events` dispatcher for API/feed callbacks
- dispatch API/feed status from `SystemMonitor`
- update GUI to subscribe for status events
- trigger API status events when credentials are saved
- test dispatcher functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871d8286a98832a9640d05fbbda95b5