### PR TITLE
Implement BitMEX symbol mapping

### DIFF
--- a/bitmex_trader.py
+++ b/bitmex_trader.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 
+from symbol_utils import bitmex_symbol
+
 import requests
 
 from exchange_interface import ExchangeAdapter
@@ -24,6 +26,7 @@ class BitmexTrader(ExchangeAdapter):
 
     def get_market_price(self, symbol: str = "XBTUSD") -> Optional[float]:
         """Return the latest market price for *symbol*."""
+        symbol = bitmex_symbol(symbol)
         try:
             url = f"{self.base_url}/instrument?symbol={symbol}"
             resp = self.session.get(url, timeout=10)
@@ -68,5 +71,6 @@ class BitmexTrader(ExchangeAdapter):
         return {}
 
     def fetch_funding_rate(self, market: str) -> Dict[str, Any]:
+        market = bitmex_symbol(market)
         params = {"symbol": market, "count": 1, "reverse": "true"}
         return self._get("/funding", **params)

--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -442,7 +442,7 @@ class TradingGUI(TradingGUILogicMixin):
 
         symbol = SETTINGS.get("symbol", "BTC_USDT")
         exch = SETTINGS.get("trading_backend", "mexc")
-        price = fetch_last_price(exch)
+        price = fetch_last_price(exch, symbol)
         stamp = datetime.now().strftime("%H:%M:%S")
         line = f"{symbol.replace('_','')}: {price:.2f} ({stamp})" if price is not None else f"{symbol}: -- ({stamp})"
         if hasattr(self, "api_frame") and hasattr(self.api_frame, "log_price"):

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -174,7 +174,9 @@ def run_bot_live(settings=None, app=None):
 
         try:
             candle = fetch_latest_candle(settings["symbol"], interval)
-            price = fetch_last_price(settings.get("trading_backend", "mexc"))
+            price = fetch_last_price(
+                settings.get("trading_backend", "mexc"), settings["symbol"]
+            )
             stamp = datetime.now().strftime("%H:%M:%S")
             if price is not None and hasattr(app, "log_event"):
                 msg = f"[{stamp}] Preis-Update: {settings['symbol']} = {price:.2f}"

--- a/symbol_utils.py
+++ b/symbol_utils.py
@@ -1,0 +1,18 @@
+"""Utility helpers for symbol name conversions."""
+
+from __future__ import annotations
+
+
+def bitmex_symbol(symbol: str) -> str:
+    """Return BitMEX-compatible symbol for common USDT pairs.
+
+    Converts standard "COINUSDT" names to BitMEX naming like "XBTUSD".
+    If *symbol* is already BitMEX style or unknown, it is returned unchanged.
+    """
+    normalized = symbol.replace("/", "").replace("_", "").upper()
+    mapping = {
+        "BTCUSDT": "XBTUSD",
+        "ETHUSDT": "ETHUSD",
+    }
+    return mapping.get(normalized, symbol)
+

--- a/tests/test_bitmex_price_feed.py
+++ b/tests/test_bitmex_price_feed.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from data_provider import fetch_last_price
+
+class BitmexPriceFeedTest(unittest.TestCase):
+    @patch('data_provider._SESSION.get')
+    def test_price_feed_mapping(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = [{"lastPrice": "123.45"}]
+        mock_get.return_value = mock_resp
+
+        price = fetch_last_price('bitmex', 'BTCUSDT')
+        self.assertAlmostEqual(price, 123.45)
+        called_url = mock_get.call_args[0][0]
+        self.assertIn('symbol=XBTUSD', called_url)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_bitmex_symbol.py
+++ b/tests/test_bitmex_symbol.py
@@ -1,0 +1,17 @@
+import unittest
+from symbol_utils import bitmex_symbol
+
+class BitmexSymbolTest(unittest.TestCase):
+    def test_btc_mapping(self):
+        self.assertEqual(bitmex_symbol('BTCUSDT'), 'XBTUSD')
+        self.assertEqual(bitmex_symbol('btc_usdt'), 'XBTUSD')
+
+    def test_eth_mapping(self):
+        self.assertEqual(bitmex_symbol('ETHUSDT'), 'ETHUSD')
+        self.assertEqual(bitmex_symbol('eth/usdt'), 'ETHUSD')
+
+    def test_unknown(self):
+        self.assertEqual(bitmex_symbol('XRPUSDT'), 'XRPUSDT')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `symbol_utils.bitmex_symbol` to map USDT pairs to BitMEX format
- convert symbols in BitMEX trader requests
- allow `fetch_last_price()` to accept a symbol and map for BitMEX
- propagate symbol to price requests in GUI and realtime runner
- add tests for symbol mapping and price feed behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871fa1b3d70832abe17d4233669dc8c