### PR TITLE
Improve sim mode safety

### DIFF
--- a/data_provider.py
+++ b/data_provider.py
@@ -60,6 +60,9 @@ def fetch_last_price(exchange: str, symbol: Optional[str] = None) -> Optional[fl
     When *symbol* is given it overrides the default symbol.  For BitMEX the
     value is converted via :func:`bitmex_symbol`.
     """
+    if exchange.lower() == "sim":
+        logging.info("Sim-Modus – Marktdaten werden nicht geladen")
+        return None
     info = PRICE_FEEDS.get(exchange.lower())
     if not info:
         raise ValueError(f"Unknown exchange '{exchange}'")

--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -443,6 +443,16 @@ class TradingGUI(TradingGUILogicMixin):
 
         symbol = SETTINGS.get("symbol", "BTC_USDT")
         exch = SETTINGS.get("trading_backend", "mexc")
+
+        if exch == "sim":
+            line = "Simulation: Keine Live-Marktdaten"
+            if hasattr(self, "api_frame") and hasattr(self.api_frame, "log_price"):
+                self.api_frame.log_price(line, error=True)
+            if hasattr(self, "log_event"):
+                self.log_event("Sim-Modus – Marktdaten werden nicht geladen")
+            self.root.after(self.market_interval_ms, self._update_market_monitor)
+            return
+
         try:
             price = fetch_last_price(exch, symbol)
         except ValueError as exc:


### PR DESCRIPTION
## Summary
- avoid real API calls in `fetch_last_price` when running with `sim` backend
- show simulation notice instead of price updates in GUI
- log missing price information in realtime runner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687203694a74832a8d0786d8344e63e5