### PR TITLE
Improve filter logging

### DIFF
--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -250,6 +250,12 @@ def run_bot_live(settings=None, app=None):
             print(log_msg)
             if hasattr(app, "log_event"):
                 app.log_event(log_msg)
+        elif andac_signal.reasons:
+            reason_msg = ", ".join(andac_signal.reasons)
+            log_msg = f"[{stamp}] Signal verworfen: {reason_msg}"
+            print(log_msg)
+            if hasattr(app, "log_event"):
+                app.log_event(log_msg)
 
         # --- POSITION HANDLING ---
         if position:


### PR DESCRIPTION
## Summary
- track filter decisions in `AndacEntryMaster.evaluate`
- include reasons in `AndacSignal`
- log rejected signals in `realtime_runner`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68720b6e0a94832aa107f771b2c90fc3