### PR TITLE
Improve API price feed handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,20 @@ Nach jedem Speichern und beim Bot-Start erfolgt automatisch eine Prüfung aller 
 ```
 
 Ohne gültige Zugangsdaten läuft der Bot nicht. Ein Simulations- oder Backtest-Modus ist nicht vorhanden – es werden ausschließlich Live-Marktdaten verwendet.
+
+### Preisfeeds & Endpunkte
+
+Für jede unterstützte Börse wird ein eigener Preisfeed-Endpunkt genutzt. Die eigentlichen
+Liveness-Checks erfolgen ausschließlich über einfache `/ping`- oder Zeit-Endpunkte.
+So bleiben Verbindungsprüfung und Marktdaten klar getrennt.
+
+| Exchange | Ping-Endpunkt | Preisfeed | Beispiel-Symbol |
+|---------|---------------|-----------|-----------------|
+| MEXC | `https://api.mexc.com/api/v3/ping` | `https://contract.mexc.com/api/v1/contract/ticker?symbol=BTC_USDT` | `BTC_USDT` |
+| BitMEX | `https://www.bitmex.com/api/v1/instrument` | `https://www.bitmex.com/api/v1/instrument?symbol=XBTUSD` | `XBTUSD` |
+| Binance | `https://api.binance.com/api/v3/ping` | `https://api.binance.com/api/v3/ticker/price?symbol=BTCUSDT` | `BTCUSDT` |
+| Bybit | `https://api.bybit.com/v2/public/time` | `https://api.bybit.com/v2/public/tickers?symbol=BTCUSDT` | `BTCUSDT` |
+| OKX | `https://www.okx.com/api/v5/public/time` | `https://www.okx.com/api/v5/market/ticker?instId=BTC-USDT-SWAP` | `BTC-USDT-SWAP` |
+
+Fehlerhafte Symbole oder API-Antworten werden im Debug-Modus vollständig geloggt, damit
+Probleme schnell erkannt werden können.

--- a/tests/test_mexc_price_feed.py
+++ b/tests/test_mexc_price_feed.py
@@ -1,0 +1,32 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from data_provider import fetch_last_price
+
+class MexcPriceFeedTest(unittest.TestCase):
+    @patch('data_provider._SESSION.get')
+    def test_price_success(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {'success': True, 'data': {'lastPrice': '99.9'}}
+        mock_get.return_value = mock_resp
+
+        price = fetch_last_price('mexc', 'BTC_USDT')
+        self.assertAlmostEqual(price, 99.9)
+        called_url = mock_get.call_args[0][0]
+        self.assertIn('symbol=BTC_USDT', called_url)
+
+    @patch('data_provider.logging.error')
+    @patch('data_provider._SESSION.get')
+    def test_symbol_error(self, mock_get, mock_log):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {'success': False, 'code': 404, 'message': '合约不存在!'}
+        mock_get.return_value = mock_resp
+
+        price = fetch_last_price('mexc', 'FOO_USDT')
+        self.assertIsNone(price)
+        mock_log.assert_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand price feed mapping to all exchanges
- normalize symbols per exchange
- improve error output for missing symbols
- document ping vs price feed separation in README
- add Mexc price feed unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687226072bb8832aae51c27dd456af6c