### PR TITLE
Implement single exchange trading mode

### DIFF
--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -475,26 +475,34 @@ class TradingGUI(TradingGUILogicMixin):
         from config import SETTINGS
 
         symbol = SETTINGS.get("symbol", "BTC_USDT")
-        exch = SETTINGS.get("trading_backend", "mexc")
+        active = SETTINGS.get("trading_backend", "mexc")
 
-        try:
-            price = fetch_last_price(exch, symbol)
-        except ValueError as exc:
-            logging.error("%s", exc)
-            if hasattr(self, "log_event"):
-                self.log_event(f"API-Fehler: {exc}")
-            price = None
-        stamp = datetime.now().strftime("%H:%M:%S")
-        line = f"{symbol.replace('_','')}: {price:.2f} ({stamp})" if price is not None else f"{symbol}: -- ({stamp})"
-        if hasattr(self, "api_frame") and hasattr(self.api_frame, "log_price"):
-            self.api_frame.log_price(line, error=price is None)
-        if price is not None:
-            msg = f"[{stamp}] Preis-Update: {symbol} = {price:.2f}"
-            print(msg)
-            self.log_event(msg)
-        else:
-            if hasattr(self, "log_event"):
-                self.log_event("API-Fehler – Antwort unvollständig")
+        if not hasattr(self, "market_prices"):
+            self.market_prices = {}
+
+        for exch in [e.lower() for e in EXCHANGES]:
+            try:
+                price = fetch_last_price(exch, symbol)
+            except ValueError as exc:
+                logging.error("%s", exc)
+                if hasattr(self, "log_event") and exch == active:
+                    self.log_event(f"API-Fehler: {exc}")
+                price = None
+            self.market_prices[exch] = price
+            if exch == active:
+                stamp = datetime.now().strftime("%H:%M:%S")
+                line = (
+                    f"{symbol.replace('_','')}: {price:.2f} ({stamp})" if price is not None else f"{symbol}: -- ({stamp})"
+                )
+                if hasattr(self, "api_frame") and hasattr(self.api_frame, "log_price"):
+                    self.api_frame.log_price(line, error=price is None)
+                if price is not None:
+                    msg = f"[{stamp}] Preis-Update: {symbol} = {price:.2f}"
+                    print(msg)
+                    self.log_event(msg)
+                else:
+                    if hasattr(self, "log_event"):
+                        self.log_event("API-Fehler – Antwort unvollständig")
         self.root.after(self.market_interval_ms, self._update_market_monitor)
 
 

--- a/tests/test_gui_credentials.py
+++ b/tests/test_gui_credentials.py
@@ -4,20 +4,22 @@ from gui.api_credential_frame import APICredentialFrame
 from api_key_manager import APICredentialManager
 
 class GUICredentialFrameTest(unittest.TestCase):
-    def test_checkbox_enables_fields(self):
+    def test_active_exchange_selection(self):
         try:
             root = tk.Tk()
         except tk.TclError:
             self.skipTest("Tkinter not available")
         frame = APICredentialFrame(root, APICredentialManager())
-        data = frame.vars["MEXC"]
-        self.assertEqual(data["entry1"].cget("state"), "disabled")
-        data["enabled"].set(True)
-        frame._toggle_exchange("MEXC")
-        self.assertEqual(data["entry1"].cget("state"), "normal")
-        data["enabled"].set(False)
-        frame._toggle_exchange("MEXC")
-        self.assertEqual(data["entry1"].cget("state"), "disabled")
+        mexc = frame.vars["MEXC"]
+        dydx = frame.vars["dYdX"]
+        # default should enable MEXC
+        self.assertEqual(mexc["entry1"].cget("state"), "normal")
+        self.assertEqual(dydx["entry1"].cget("state"), "disabled")
+        # switch to dYdX
+        frame.active_exchange.set("dYdX")
+        frame._select_exchange("dYdX")
+        self.assertEqual(dydx["entry1"].cget("state"), "normal")
+        self.assertEqual(mexc["entry1"].cget("state"), "disabled")
         root.destroy()
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add active exchange dropdown in `APICredentialFrame`
- disable credential fields for non-selected exchanges
- store selected exchange in settings and keep all feeds active
- update market monitor to fetch prices for all exchanges
- adapt GUI credentials test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6872b01a7594832a923be10092b6c64c