### PR TITLE
Update exchange status display handling

### DIFF
--- a/gui/api_credential_frame.py
+++ b/gui/api_credential_frame.py
@@ -12,10 +12,11 @@ EXCHANGES = ["MEXC", "dYdX", "Binance", "Bybit", "BitMEX"]
 class APICredentialFrame(ttk.LabelFrame):
     """GUI frame for managing multiple exchange credentials."""
 
-    def __init__(self, master: tk.Misc, cred_manager: APICredentialManager, log_callback=None) -> None:
+    def __init__(self, master: tk.Misc, cred_manager: APICredentialManager, log_callback=None, select_callback=None) -> None:
         super().__init__(master, text="Exchange API")
         self.cred_manager = cred_manager
         self.log_callback = log_callback
+        self.select_callback = select_callback
 
         self.active_exchange = tk.StringVar(value=EXCHANGES[0])
 
@@ -61,6 +62,8 @@ class APICredentialFrame(ttk.LabelFrame):
         ttk.Button(self, text="Speichern", command=self._save).grid(row=start_row + len(EXCHANGES), column=0, pady=5, sticky="w")
 
         self._select_exchange(self.active_exchange.get())
+        if self.select_callback:
+            self.select_callback(self.active_exchange.get())
 
         # Mini price monitor
         term_frame = tk.Frame(self, bg="black")
@@ -78,6 +81,8 @@ class APICredentialFrame(ttk.LabelFrame):
             if name != exch:
                 self.status_vars[name].set("⚪")
                 self.status_labels[name].config(foreground="grey")
+        if self.select_callback:
+            self.select_callback(exch)
 
     def log_price(self, text: str, error: bool = False) -> None:
         color = "red" if error else "green"

--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -153,6 +153,7 @@ class TradingGUI(TradingGUILogicMixin):
         # Statusvariablen je Exchange
         self.exchange_status_vars = {ex: tk.StringVar(value="⚪") for ex in EXCHANGES}
         self.exchange_status_labels = {}
+        self.exchange_status_cache = {}
 
     def _build_gui(self):
         # wrapper for main content to allow side panels
@@ -339,11 +340,20 @@ class TradingGUI(TradingGUILogicMixin):
             ttk.Entry(parent, textvariable=var).pack()
 
     def _build_api_credentials(self, parent):
-        self.api_frame = APICredentialFrame(parent, self.cred_manager, log_callback=self.log_event)
+        self.api_frame = APICredentialFrame(
+            parent,
+            self.cred_manager,
+            log_callback=self.log_event,
+            select_callback=self._on_exchange_select,
+        )
         self.api_frame.pack(pady=(0, 10), fill="x")
         for exch in EXCHANGES:
             self.exchange_status_vars[exch] = self.api_frame.status_vars[exch]
             self.exchange_status_labels[exch] = self.api_frame.status_labels[exch]
+
+    def _on_exchange_select(self, exch: str) -> None:
+        if hasattr(self, "on_exchange_select"):
+            self.on_exchange_select(exch)
 
 
     # ---- Status Panel -------------------------------------------------

--- a/gui/trading_gui_logic.py
+++ b/gui/trading_gui_logic.py
@@ -220,6 +220,11 @@ class TradingGUILogicMixin:
 
     def update_exchange_status(self, exchange: str, ok: bool) -> None:
         if hasattr(self, "exchange_status_vars") and exchange in self.exchange_status_vars:
+            cache = getattr(self, "exchange_status_cache", None)
+            if cache is not None:
+                cache[exchange] = ok
+            if getattr(self.api_frame, "active_exchange", tk.StringVar()).get() != exchange:
+                return
             if getattr(self, "_last_exchange_status", {}).get(exchange) == ok:
                 return
             self._last_exchange_status = getattr(self, "_last_exchange_status", {})
@@ -237,6 +242,34 @@ class TradingGUILogicMixin:
                     lbl.config(foreground="red")
                     if not lbl.winfo_ismapped():
                         lbl.pack(side="left", padx=5)
+
+    def on_exchange_select(self, exch: str) -> None:
+        cache = getattr(self, "exchange_status_cache", None)
+        if cache is None:
+            return
+        ok = cache.get(exch)
+        lbl = self.exchange_status_labels.get(exch)
+        if ok is None:
+            self.exchange_status_vars[exch].set("⚪")
+            if lbl and lbl.winfo_ismapped():
+                lbl.pack_forget()
+            if lbl:
+                lbl.config(foreground="grey")
+            return
+        self._last_exchange_status = getattr(self, "_last_exchange_status", {})
+        self._last_exchange_status[exch] = ok
+        if ok:
+            if lbl and lbl.winfo_ismapped():
+                lbl.pack_forget()
+            self.exchange_status_vars[exch].set("")
+        else:
+            stamp = datetime.now().strftime("%H:%M:%S")
+            text = f"{exch} ❌ ({stamp})"
+            self.exchange_status_vars[exch].set(text)
+            if lbl:
+                lbl.config(foreground="red")
+                if not lbl.winfo_ismapped():
+                    lbl.pack(side="left", padx=5)
 
     def update_pnl(self, pnl):
         self.log_event(f"💰 Trade abgeschlossen: PnL {pnl:.2f} $")


### PR DESCRIPTION
## Summary
- allow passing a selection callback to `APICredentialFrame`
- track exchange status per exchange and only update GUI for the selected one
- restore status for newly selected exchanges

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6872b27ccc34832aa5cb89c90f026f15