### PR TITLE
Add OKX exchange and lazy status check

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Alternativ können die gleichen Werte im `tuning_config.json` hinterlegt werden 
 
 ### Dynamische API-Eingabe in der GUI
 
-In der GUI kann die gewünschte Börse ausgewählt werden. Je nach Auswahl erscheinen passende Felder (API Key/Secret oder Wallet/Private Key). Eingaben werden live validiert und nur im Arbeitsspeicher gespeichert. Auch beim Start über die Kommandozeile werden alle vorhandenen Zugangsdaten sofort geprüft.
+In der GUI kann die gewünschte Börse ausgewählt werden. Je nach Auswahl erscheinen passende Felder (API Key/Secret oder Wallet/Private Key). Eingaben werden live validiert und nur im Arbeitsspeicher gespeichert. Beim Programmstart ist keine Exchange aktiv; erst nach einer Auswahl werden die Zugangsdaten geprüft und der Status angezeigt. Auch beim Start über die Kommandozeile werden alle vorhandenen Zugangsdaten sofort geprüft.
 
 Nach jedem Speichern und beim Bot-Start erfolgt automatisch eine Prüfung aller hinterlegten Exchanges. Das Ergebnis wird mit Zeitstempel im Log ausgegeben, z.B.:
 

--- a/tests/test_check_all_credentials.py
+++ b/tests/test_check_all_credentials.py
@@ -53,5 +53,21 @@ class AllCredentialCheckTest(unittest.TestCase):
         del os.environ['MEXC_API_KEY']
         del os.environ['MEXC_API_SECRET']
 
+    @patch('mexc_api_utils.requests.get')
+    @patch('credential_checker.requests.get', return_value=MagicMock(status_code=200, text='OK'))
+    @patch('dydx_api_utils.requests.get', return_value=MagicMock(status_code=200, text='OK'))
+    def test_okx_env_credentials(self, mock_dydx, mock_get, mock_mexc):
+        mock_get.return_value.raise_for_status.return_value = None
+        mock_mexc_resp = MagicMock()
+        mock_mexc_resp.json.return_value = {'success': False}
+        mock_mexc.return_value = mock_mexc_resp
+        mock_dydx.return_value.raise_for_status.return_value = None
+        os.environ['OKX_API_KEY'] = 'okxkey'
+        os.environ['OKX_API_SECRET'] = 'okxsecret'
+        res = check_all_credentials({})
+        self.assertIn('okx', res['active'])
+        del os.environ['OKX_API_KEY']
+        del os.environ['OKX_API_SECRET']
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_credential_checker.py
+++ b/tests/test_credential_checker.py
@@ -57,6 +57,15 @@ class CredentialCheckerTest(unittest.TestCase):
         self.assertTrue(ok)
         self.assertIn('BitMEX', msg)
 
+    @patch('credential_checker.requests.get')
+    def test_okx_success(self, mock_get):
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.raise_for_status.return_value = None
+        mock_get.return_value = mock_resp
+        ok, msg = check_exchange_credentials('OKX', key='abcd1', secret='xyzt1')
+        self.assertTrue(ok)
+        self.assertIn('OKX', msg)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_gui_credentials.py
+++ b/tests/test_gui_credentials.py
@@ -12,12 +12,12 @@ class GUICredentialFrameTest(unittest.TestCase):
         frame = APICredentialFrame(root, APICredentialManager())
         mexc = frame.vars["MEXC"]
         dydx = frame.vars["dYdX"]
-        # default should enable MEXC
-        self.assertEqual(mexc["entry1"].cget("state"), "normal")
+        # no exchange selected by default
+        self.assertEqual(mexc["entry1"].cget("state"), "disabled")
         self.assertEqual(dydx["entry1"].cget("state"), "disabled")
         # switch to dYdX
         frame.active_exchange.set("dYdX")
-        frame._select_exchange("dYdX")
+        frame._on_select()
         self.assertEqual(dydx["entry1"].cget("state"), "normal")
         self.assertEqual(mexc["entry1"].cget("state"), "disabled")
         root.destroy()


### PR DESCRIPTION
## Summary
- add OKX to the exchange list
- disable API check until the user selects an exchange
- include helper to handle empty selection
- update tests for new behaviour and OKX
- document that no exchange is active on startup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6872b54cd5cc832abeed1bb0a002b3b7