### PR TITLE
Implement live/paper trading toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Handelsergebnisse.
 * Orderausführung über die vorhandene **BitmexTrader**-Klasse
 * Symbolmapping: `BTCUSDT` → `XBTUSD` mittels `bitmex_symbol()`
 * Optionaler Paper-Trading-Modus mit realistischer PnL-Berechnung
+* Umschaltbarer Live-Trading-Modus über die GUI
 * Keine Unterstützung für andere Börsen
 
 ## Installation
@@ -32,5 +33,5 @@ hinterlegt sind.
 python main.py
 ```
 Die GUI fragt die BitMEX-Zugangsdaten ab und zeigt fortlaufend die Binance-Spot-
-Preise sowie die Entwicklung des Paper-Trading-Kontos an.
+Preise sowie die Entwicklung des Paper-Trading-Kontos an. Über einen Schalter kann jederzeit vom Simulationsmodus in den Live-Betrieb gewechselt werden.
 

--- a/config.py
+++ b/config.py
@@ -13,4 +13,5 @@ SETTINGS = {
     "auto_multiplier": False,
     "capital": 1000,
     "version": "V10.4_Pro",
+    "paper_mode": True,
 }

--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -44,6 +44,8 @@ class TradingGUI(TradingGUILogicMixin):
         self.capital_entry = None
         self.log_box = None
         self.auto_status_label = None
+        self.live_trading = tk.BooleanVar(value=False)
+        self.mode_label = None
 
         self._init_variables()
         self._build_gui()
@@ -91,6 +93,16 @@ class TradingGUI(TradingGUILogicMixin):
     def _update_neon_var(self, key, var):
         color = "green" if var.get() else "blue"
         self.neon_panel.set_status(key, color)
+
+    def _update_mode_label(self):
+        if self.live_trading.get():
+            text = "Live-Modus"
+            color = "red"
+        else:
+            text = "Simulationsmodus"
+            color = "blue"
+        if self.mode_label is not None:
+            self.mode_label.config(text=text, foreground=color)
 
     def _init_variables(self):
         self.multiplier_var = tk.StringVar(value="20")
@@ -174,6 +186,10 @@ class TradingGUI(TradingGUILogicMixin):
         self.api_status_label.pack(side="left", padx=10)
         self.feed_status_label = ttk.Label(top_info, textvariable=self.feed_status_var, foreground="red", font=("Arial", 11, "bold"))
         self.feed_status_label.pack(side="left", padx=10)
+        self.mode_label = ttk.Label(top_info, text="Simulationsmodus", foreground="blue", font=("Arial", 11, "bold"))
+        self.mode_label.pack(side="left", padx=10)
+        ttk.Checkbutton(top_info, text="Live-Trading", variable=self.live_trading, command=self._update_mode_label).pack(side="left")
+        self._update_mode_label()
 
         # --- Hauptcontainer ---
         container = ttk.Frame(self.main_frame)

--- a/gui_bridge.py
+++ b/gui_bridge.py
@@ -76,6 +76,15 @@ class GUIBridge:
                 return SETTINGS.get("interval", "15m")
         return SETTINGS.get("interval", "15m")
 
+    @property
+    def live_trading(self):
+        if self.gui and hasattr(self.gui, "live_trading"):
+            try:
+                return bool(self.gui.live_trading.get())
+            except Exception:
+                return not SETTINGS.get("paper_mode", True)
+        return not SETTINGS.get("paper_mode", True)
+
 
 
     def update_live_pnl(self, pnl):

--- a/main.py
+++ b/main.py
@@ -47,7 +47,9 @@ def bot_control(gui):
         if cmd == "start":
             if not gui.running:
                 load_settings_from_file()
-                print("🚀 Bot gestartet: LIVE-MODUS")
+                SETTINGS["paper_mode"] = not gui.live_trading.get()
+                mode_text = "LIVE-MODUS" if gui.live_trading.get() else "SIMULATIONS-MODUS"
+                print(f"🚀 Bot gestartet: {mode_text}")
                 gui.running = True
                 threading.Thread(target=run_bot_live, args=(SETTINGS, gui), daemon=True).start()
             else:
@@ -102,7 +104,7 @@ def bot_control(gui):
                 status = (
                     f"{farbe} Aktueller PnL: ${pnl:.1f} | Laufzeit: {laufzeit}s | ⏰ {uhrzeit} | 📅 {datum}\n"
                     f"💼 Kapital: ${capital:.2f} | 📊 Lev: x{leverage} | 📍 Trade: {trade_info}\n"
-                    f"📉 ATR: ${atr_value_global:.1f} | 📈 EMA: {ema_trend_global} | 🚀 Modus: LIVE\n"
+                    f"📉 ATR: ${atr_value_global:.1f} | 📈 EMA: {ema_trend_global} | 🚀 Modus: {'LIVE' if gui.live_trading.get() else 'SIMULATION'}\n"
                     f"{filter_line}"
                 )
                 print(status + Style.RESET_ALL)
@@ -122,7 +124,9 @@ def on_gui_start(gui):
         return
     load_settings_from_file()
     SETTINGS["interval"] = gui.interval.get()
-    print("🚀 Bot gestartet: LIVE-MODUS")
+    SETTINGS["paper_mode"] = not gui.live_trading.get()
+    mode_text = "LIVE-MODUS" if gui.live_trading.get() else "SIMULATIONS-MODUS"
+    print(f"🚀 Bot gestartet: {mode_text}")
     gui.running = True
     threading.Thread(target=run_bot_live, args=(SETTINGS, gui), daemon=True).start()
 

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -108,6 +108,8 @@ def run_bot_live(settings=None, app=None):
     start_capital = capital                  # <--- Startwert merken für Verlustlimit
     interval = gui_bridge.interval
     auto_multi = gui_bridge.auto_multiplier
+    live_trading = gui_bridge.live_trading and API_KEY and API_SECRET
+    settings["paper_mode"] = not live_trading
 
     leverage = multiplier
     # interval wird aus GUI übernommen, NICHT überschreiben!
@@ -310,7 +312,7 @@ def run_bot_live(settings=None, app=None):
                         )
                         app.log_event(log_msg)
                         app.apc_status_label.config(text=log_msg, foreground="blue")
-                        if trader:
+                        if trader and live_trading:
                             live_partial_close(trader, settings["symbol"], position["side"], to_close)
                         if position["amount"] <= 0:
                             position = None
@@ -425,7 +427,7 @@ def run_bot_live(settings=None, app=None):
 
 
 
-                if amount > 0:
+                if amount > 0 and trader and live_trading:
                     try:
                         direction = "BUY" if entry_type == "long" else "SELL"
                         trader.place_order(

--- a/strategy.py
+++ b/strategy.py
@@ -8,12 +8,12 @@ def execute_trading_strategy(settings, gui):
     if hasattr(gui, "log_event"):
         gui.log_event(msg)
 
-    strategy_mode = settings.get("strategy_mode", "live")
+    strategy_mode = "live" if not settings.get("paper_mode", True) else "paper"
 
     try:
         if strategy_mode == "live":
             from realtime_runner import run_bot_live
-            msg = "🚀 Modus: LIVE aktiviert"
+            msg = "🚀 Modus: LIVE aktiviert" if not settings.get("paper_mode", True) else "🚀 Modus: SIMULATION"
             print(msg)
             if hasattr(gui, "log_event"):
                 gui.log_event(msg)


### PR DESCRIPTION
## Summary
- introduce `paper_mode` option in config
- add GUI switch showing current mode and controlling live trading
- expose `live_trading` flag through GUIBridge
- adapt main, strategy, and realtime runner to respect the mode
- update README with new instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6872e7b4180c832aa5f090634808741e