### PR TITLE
Add live/paper toggle with safety checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,19 @@ python main.py
 Die GUI fragt die BitMEX-Zugangsdaten ab und zeigt fortlaufend die Binance-Spot-
 Preise sowie die Entwicklung des Paper-Trading-Kontos an. Über einen Schalter kann jederzeit vom Simulationsmodus in den Live-Betrieb gewechselt werden.
 
+## Trading-Modi: Paper vs. Live
+
+- **Einstieg & Ausstieg erfolgen immer anhand echter Binance BTCUSDT Marktdaten**
+- Die Handelsentscheidung basiert auf dem integrierten EntryMaster-Indikator
+- Zwei Modi:
+  - 🧪 **Paper Trading** (Standard):
+    - Trades werden simuliert
+    - PnL, Kapitalverlauf und Logik sind identisch zum Live-Modus
+    - Keine echte Orderausführung – auch bei gesetzten BitMEX-Keys
+  - 💼 **Live Trading**:
+    - Orderausführung über BitMEX (XBTUSD)
+    - Nur aktiv, wenn der Schalter umgelegt und gültige API-Keys vorhanden sind
+
+- In der GUI befindet sich ein klar gekennzeichneter Toggle-Switch zur Moduswahl
+- Das System ist **fehlertolerant** – im Paper-Modus sind echte Trades **technisch ausgeschlossen**
+

--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -45,6 +45,7 @@ class TradingGUI(TradingGUILogicMixin):
         self.log_box = None
         self.auto_status_label = None
         self.live_trading = tk.BooleanVar(value=False)
+        self.trading_mode = tk.StringVar(value="paper")
         self.mode_label = None
 
         self._init_variables()
@@ -96,13 +97,17 @@ class TradingGUI(TradingGUILogicMixin):
 
     def _update_mode_label(self):
         if self.live_trading.get():
-            text = "Live-Modus"
+            text = "Live Trading"
             color = "red"
         else:
-            text = "Simulationsmodus"
+            text = "Paper Trading"
             color = "blue"
         if self.mode_label is not None:
             self.mode_label.config(text=text, foreground=color)
+
+    def _on_mode_toggle(self):
+        self.live_trading.set(self.trading_mode.get() == "live")
+        self._update_mode_label()
 
     def _init_variables(self):
         self.multiplier_var = tk.StringVar(value="20")
@@ -186,10 +191,26 @@ class TradingGUI(TradingGUILogicMixin):
         self.api_status_label.pack(side="left", padx=10)
         self.feed_status_label = ttk.Label(top_info, textvariable=self.feed_status_var, foreground="red", font=("Arial", 11, "bold"))
         self.feed_status_label.pack(side="left", padx=10)
-        self.mode_label = ttk.Label(top_info, text="Simulationsmodus", foreground="blue", font=("Arial", 11, "bold"))
+        self.mode_label = ttk.Label(top_info, text="Paper Trading", foreground="blue", font=("Arial", 11, "bold"))
         self.mode_label.pack(side="left", padx=10)
-        ttk.Checkbutton(top_info, text="Live-Trading", variable=self.live_trading, command=self._update_mode_label).pack(side="left")
-        self._update_mode_label()
+
+        mode_frame = ttk.Frame(top_info)
+        mode_frame.pack(side="left")
+        ttk.Radiobutton(
+            mode_frame,
+            text="Paper Trading",
+            variable=self.trading_mode,
+            value="paper",
+            command=self._on_mode_toggle,
+        ).pack(side="left")
+        ttk.Radiobutton(
+            mode_frame,
+            text="Live Trading",
+            variable=self.trading_mode,
+            value="live",
+            command=self._on_mode_toggle,
+        ).pack(side="left")
+        self._on_mode_toggle()
 
         # --- Hauptcontainer ---
         container = ttk.Frame(self.main_frame)

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -108,7 +108,10 @@ def run_bot_live(settings=None, app=None):
     start_capital = capital                  # <--- Startwert merken für Verlustlimit
     interval = gui_bridge.interval
     auto_multi = gui_bridge.auto_multiplier
-    live_trading = gui_bridge.live_trading and API_KEY and API_SECRET
+
+    live_requested = gui_bridge.live_trading and API_KEY and API_SECRET
+    paper_mode = settings.get("paper_mode", True)
+    live_trading = live_requested and not paper_mode
     settings["paper_mode"] = not live_trading
 
     leverage = multiplier
@@ -137,7 +140,7 @@ def run_bot_live(settings=None, app=None):
 
     TraderClass = import_trader(settings.get("trading_backend", "bitmex"))
     trader = None
-    if TraderClass:
+    if TraderClass and live_trading:
         trader = TraderClass(
             api_key=API_KEY,
             api_secret=API_SECRET


### PR DESCRIPTION
## Summary
- switch GUI to radio-style toggle for trading mode
- ensure backend enforces paper mode when selected
- update documentation about trading modes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6872ea0bc9e8832ab6003f8803cb9491