### PR TITLE
Add Binance feed status indicator

### DIFF
--- a/data_provider.py
+++ b/data_provider.py
@@ -42,20 +42,14 @@ def fetch_last_price(exchange: str = "binance", symbol: Optional[str] = None) ->
         raise ValueError("Only Binance spot data supported")
 
     pair = _normalize_symbol(symbol or "BTCUSDT")
-    now = datetime.now().strftime("%H:%M:%S")
     try:
         data = _BINANCE.get_symbol_ticker(symbol=pair)
         price = float(data["price"])
+        logging.debug("Price update %s: %.2f", pair, price)
+        return price
     except Exception as exc:
-        msg = f"{pair}: -- ({now}) | ERROR: {exc}"
-        logging.error(msg)
-        print(msg)
+        logging.debug("Failed to fetch %s: %s", pair, exc)
         return None
-
-    msg = f"{pair}: {price:.2f} ({now})"
-    logging.info(msg)
-    print(msg)
-    return price
 
 def get_latest_candle_batch(
     symbol: str = "BTCUSDT", interval: str = "1m", limit: int = 100

--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -530,10 +530,7 @@ class TradingGUI(TradingGUILogicMixin):
         for exch in [e.lower() for e in EXCHANGES]:
             try:
                 price = fetch_last_price(exch, symbol)
-            except ValueError as exc:
-                logging.error("%s", exc)
-                if hasattr(self, "log_event") and exch == active:
-                    self.log_event(f"API-Fehler: {exc}")
+            except ValueError:
                 price = None
             self.market_prices[exch] = price
             if exch == active:
@@ -544,12 +541,9 @@ class TradingGUI(TradingGUILogicMixin):
                 if hasattr(self, "api_frame") and hasattr(self.api_frame, "log_price"):
                     self.api_frame.log_price(line, error=price is None)
                 if price is not None:
-                    msg = f"[{stamp}] Preis-Update: {symbol} = {price:.2f}"
-                    print(msg)
-                    self.log_event(msg)
+                    self.update_feed_status(True)
                 else:
-                    if hasattr(self, "log_event"):
-                        self.log_event("API-Fehler – Antwort unvollständig")
+                    self.update_feed_status(False, "Keine Marktdaten – bitte prüfen")
         self.root.after(self.market_interval_ms, self._update_market_monitor)
 
 

--- a/gui/trading_gui_logic.py
+++ b/gui/trading_gui_logic.py
@@ -206,6 +206,8 @@ class TradingGUILogicMixin:
                 self.feed_status_var.set("")
             if hasattr(self, "neon_panel"):
                 self.neon_panel.set_status("feed", "green", "Feed OK")
+            if hasattr(self, "api_frame") and hasattr(self.api_frame, "update_market_status"):
+                self.api_frame.update_market_status(True)
         else:
             stamp = datetime.now().strftime("%H:%M:%S")
             text = f"Feed ❌" + (f" – {reason} ({stamp})" if reason else f" ({stamp})")
@@ -217,6 +219,8 @@ class TradingGUILogicMixin:
                     self.feed_status_label.pack(side="left", padx=10)
             if hasattr(self, "neon_panel"):
                 self.neon_panel.set_status("feed", "red", text)
+            if hasattr(self, "api_frame") and hasattr(self.api_frame, "update_market_status"):
+                self.api_frame.update_market_status(False)
 
     def update_exchange_status(self, exchange: str, ok: bool) -> None:
         if hasattr(self, "exchange_status_vars") and exchange in self.exchange_status_vars:

--- a/system_monitor.py
+++ b/system_monitor.py
@@ -18,6 +18,7 @@ from typing import Optional
 from config import SETTINGS
 from credential_checker import check_all_credentials
 from status_events import StatusDispatcher
+import logging
 import global_state
 
 DISPLAY_NAMES = {
@@ -77,7 +78,7 @@ class SystemMonitor:
             if hasattr(self.gui, "log_event"):
                 self.gui.log_event(full)
             else:
-                print(full)
+                logging.getLogger(__name__).info(full)
 
     def _run(self) -> None:
         while self._running:


### PR DESCRIPTION
## Summary
- give `fetch_last_price` silent logging only
- show market feed status in API section
- propagate feed status changes to new label
- stop printing API errors to console
- route system monitor messages to logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6872ee7439bc832ab4ddc133a2b0e22b