### PR TITLE
Suppress noisy API errors

### DIFF
--- a/data_provider.py
+++ b/data_provider.py
@@ -37,9 +37,13 @@ class Candle(TypedDict):
 
 
 def fetch_last_price(exchange: str = "binance", symbol: Optional[str] = None) -> Optional[float]:
-    """Return the latest price from Binance Spot."""
+    """Return the latest price from Binance Spot.
+
+    For unsupported exchanges ``None`` is returned silently.
+    """
     if exchange.lower() != "binance":
-        raise ValueError("Only Binance spot data supported")
+        logging.debug("Ignoring price request for unsupported exchange %s", exchange)
+        return None
 
     pair = _normalize_symbol(symbol or "BTCUSDT")
     try:

--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -528,10 +528,13 @@ class TradingGUI(TradingGUILogicMixin):
             self.market_prices = {}
 
         for exch in [e.lower() for e in EXCHANGES]:
-            try:
-                price = fetch_last_price(exch, symbol)
-            except ValueError:
-                price = None
+            if exch == "bitmex":
+                key = self.cred_manager.get_key() if hasattr(self, "cred_manager") else None
+                secret = self.cred_manager.get_secret() if hasattr(self, "cred_manager") else None
+                if not (key and secret):
+                    self.market_prices[exch] = None
+                    continue
+            price = fetch_last_price(exch, symbol)
             self.market_prices[exch] = price
             if exch == active:
                 stamp = datetime.now().strftime("%H:%M:%S")

--- a/system_monitor.py
+++ b/system_monitor.py
@@ -113,8 +113,8 @@ class SystemMonitor:
                 info = f"{type(exc).__name__}: {exc}"
                 if 'creds' in locals():
                     info += f" | creds={creds!r}"
-                self._log(f"Systemmonitor Fehler: {info}")
-                self._handle_feed_down("API-Fehler – Antwort unvollständig")
+                logging.debug("Systemmonitor exception: %s", info)
+                self._handle_feed_down("API-Fehler – Antwort unvollständig", log=False)
             time.sleep(self.interval)
 
     # ---- State Handlers -------------------------------------------------
@@ -145,10 +145,11 @@ class SystemMonitor:
             StatusDispatcher.dispatch("api", True)
         self._api_ok = True
 
-    def _handle_feed_down(self, reason: str) -> None:
+    def _handle_feed_down(self, reason: str, *, log: bool = True) -> None:
         if self._feed_ok:
             _beep()
-            self._log(f"{reason} – Bot pausiert")
+            if log:
+                self._log(f"{reason} – Bot pausiert")
             if hasattr(self.gui, "update_feed_status"):
                 self.gui.update_feed_status(False, reason)
             StatusDispatcher.dispatch("feed", False, reason)


### PR DESCRIPTION
## Summary
- avoid exceptions for unsupported markets in `fetch_last_price`
- hide monitor exceptions from the GUI
- skip BitMEX feed when no keys are present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6872f22bf544832a823d1767e2e81d90