### PR TITLE
Improve GUI status display and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,26 @@ Preise sowie die Entwicklung des Paper-Trading-Kontos an. Über einen Schalter k
 - Diese Anzeige dient als Live-Status zur Preisreferenz für Nutzer und zur Verifikation des Systemzustands.
 - Bei Verbindungsproblemen wird "❌" angezeigt.
 
+## 🖥️ Grafische Oberfläche (GUI)
+
+### ✅ Live-Status & Systemanzeige
+
+- **Marktdatenstatus**:
+  - In der GUI wird angezeigt, ob Binance BTCUSDT-Marktdaten erfolgreich empfangen werden.
+  - Beispiel: `✅ Marktdaten kommen an`
+
+- **Wirksamkeitsstatus**:
+  - Direkt daneben wird der Zustand des Systems bewertet.
+  - Beispiel: `✅ Alle Systeme laufen fehlerfrei` oder `❌ System macht Fehler!`
+
+- **Fehleranzeige im Log**:
+  - Wenn ein Problem erkannt wird, erscheint unten im GUI-Log ein Eintrag mit Zeitstempel und Fehlerursache – aber nur einmal pro Fehler (kein Spam).
+
+- **Status-Glühbirnen (rechts)**:
+  - Zeigen kompakten Überblick über Systemelemente wie:
+    - BitMEX API verbunden
+    - Paper-Trading aktiv
+    - Preisfeed OK
+    - Konfiguration gespeichert
+  - Farbige Punkte mit Beschreibungstooltips
+

--- a/gui/api_credential_frame.py
+++ b/gui/api_credential_frame.py
@@ -61,8 +61,16 @@ class APICredentialFrame(ttk.LabelFrame):
         ttk.Button(self, text="Speichern", command=self._save).grid(row=start_row + len(EXCHANGES), column=0, pady=5, sticky="w")
 
         self.market_status = tk.StringVar(value="")
-        self.market_status_label = ttk.Label(self, textvariable=self.market_status, foreground="red")
-        self.market_status_label.grid(row=start_row + len(EXCHANGES) + 1, column=0, columnspan=3, sticky="w")
+
+        status_row = ttk.Frame(self)
+        status_row.grid(row=start_row + len(EXCHANGES) + 1, column=0, columnspan=4, sticky="w")
+
+        self.market_status_label = ttk.Label(status_row, textvariable=self.market_status, foreground="red")
+        self.market_status_label.pack(side="left")
+
+        self.system_status = tk.StringVar(value="")
+        self.system_status_label = ttk.Label(status_row, textvariable=self.system_status, foreground="green")
+        self.system_status_label.pack(side="left", padx=(10, 0))
 
         # disable all fields until user actively chooses an exchange
         self._select_exchange("")


### PR DESCRIPTION
## Summary
- streamline GUI with compact market/system status row
- log unique effectiveness errors with timestamp
- ignore irrelevant API messages in log
- add neon indicators for paper mode and saved config
- document new status features in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6872f9c8aa58832a9b724f92e5f70519