### PR TITLE
Improve status bulbs layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,15 @@ Preise sowie die Entwicklung des Paper-Trading-Kontos an. Über einen Schalter k
 - **Fehleranzeige im Log**:
   - Wenn ein Problem erkannt wird, erscheint unten im GUI-Log ein Eintrag mit Zeitstempel und Fehlerursache – aber nur einmal pro Fehler (kein Spam).
 
-- **Status-Glühbirnen (rechts)**:
-  - Zeigen kompakten Überblick über Systemelemente wie:
-    - BitMEX API verbunden
-    - Paper-Trading aktiv
-    - Preisfeed OK
-    - Konfiguration gespeichert
-  - Farbige Punkte mit Beschreibungstooltips
+### 🌐 Statusanzeige: System-Glühbirnen
+
+- Rechts in der GUI befindet sich eine eigene Status-Spalte mit Glühbirnen-Icons
+  für jede wichtige Komponente.
+- Der Status wird farblich angezeigt (Grün/Rot) und live aktualisiert.
+- Beispiele:
+  - ✅ Preisfeed OK
+  - ✅ Paper-Trading aktiv
+  - ❌ BitMEX API nicht gesetzt
+- Bei vielen Einträgen wird eine **zweite Spalte automatisch erzeugt**, um alle
+  Informationen sichtbar zu halten – ohne Scrollen oder Abschneiden.
 


### PR DESCRIPTION
## Summary
- reorganize `NeonStatusPanel` to automatically split into multiple columns
- document new GUI status column in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687300030af0832a9b4b51a64771393c