### PR TITLE
Add selectable market data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Handelsergebnisse.
 
 ## Eigenschaften
 * Preisfeed über **python-binance** (BTCUSDT)
+* Wählbare Marktdatenquelle: REST, WebSocket oder Auto
 * Orderausführung über die vorhandene **BitmexTrader**-Klasse
 * Symbolmapping: `BTCUSDT` → `XBTUSD` mittels `bitmex_symbol()`
 * Optionaler Paper-Trading-Modus mit realistischer PnL-Berechnung

--- a/config.py
+++ b/config.py
@@ -12,6 +12,7 @@ SETTINGS = {
     "multiplier": 20,
     "auto_multiplier": False,
     "capital": 1000,
+    "data_source_mode": "rest",  # rest | websocket | auto
     "version": "V10.4_Pro",
     "paper_mode": True,
 }

--- a/tests/test_gui_credentials.py
+++ b/tests/test_gui_credentials.py
@@ -19,5 +19,14 @@ class GUICredentialFrameTest(unittest.TestCase):
         self.assertEqual(bitmex["entry1"].cget("state"), "normal")
         root.destroy()
 
+    def test_default_data_source(self):
+        try:
+            root = tk.Tk()
+        except tk.TclError:
+            self.skipTest("Tkinter not available")
+        frame = APICredentialFrame(root, APICredentialManager())
+        self.assertEqual(frame.data_source_mode.get(), "rest")
+        root.destroy()
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `data_source_mode` setting in config
- introduce GUI option to choose REST, WebSocket or Auto
- store selected mode in config when saving credentials
- prepare websocket placeholders in `data_provider`
- document selectable market data source
- test default data source in GUI

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873074c5f38832aa0f85915deed0784