### PR TITLE
Add live feed mode display

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Preise sowie die Entwicklung des Paper-Trading-Kontos an. Über einen Schalter k
 - **Wirksamkeitsstatus**:
   - Direkt daneben wird der Zustand des Systems bewertet.
   - Beispiel: `✅ Alle Systeme laufen fehlerfrei` oder `❌ System macht Fehler!`
+- **Datenfeed-Modusanzeige**:
+  - Neben dem Systemstatus wird live angezeigt, ob die Binance-Daten 
+    per WebSocket oder REST empfangen werden.
+  - Die Anzeige passt sich automatisch an und ist farblich markiert.
+  - Beispiele:
+    - `✅ Alle Systeme laufen fehlerfrei | 🟢 WebSocket kommt an`
+    - `✅ Alle Systeme laufen fehlerfrei | 🔴 REST kommt an`
 
 - **Fehleranzeige im Log**:
   - Wenn ein Problem erkannt wird, erscheint unten im GUI-Log ein Eintrag mit Zeitstempel und Fehlerursache – aber nur einmal pro Fehler (kein Spam).

--- a/config.py
+++ b/config.py
@@ -14,4 +14,6 @@ SETTINGS = {
     "capital": 1000,
     "version": "V10.4_Pro",
     "paper_mode": True,
+    # Datenquelle für Marktdaten: websocket | rest | auto
+    "data_source_mode": "auto",
 }

--- a/gui/api_credential_frame.py
+++ b/gui/api_credential_frame.py
@@ -72,6 +72,11 @@ class APICredentialFrame(ttk.LabelFrame):
         self.system_status_label = ttk.Label(status_row, textvariable=self.system_status, foreground="green")
         self.system_status_label.pack(side="left", padx=(10, 0))
 
+        # Anzeige, ob Daten via WebSocket oder REST empfangen werden
+        self.feed_mode = tk.StringVar(value="")
+        self.feed_mode_label = ttk.Label(status_row, textvariable=self.feed_mode, foreground="green")
+        self.feed_mode_label.pack(side="left", padx=(10, 0))
+
         # disable all fields until user actively chooses an exchange
         self._select_exchange("")
 

--- a/gui/trading_gui_logic.py
+++ b/gui/trading_gui_logic.py
@@ -199,6 +199,7 @@ class TradingGUILogicMixin:
             return
         self._last_feed_status = (ok, reason)
         self.feed_ok = ok
+        self._update_feed_mode_display(ok)
         if ok:
             if hasattr(self, "feed_status_label") and self.feed_status_label.winfo_ismapped():
                 self.feed_status_label.pack_forget()
@@ -221,6 +222,37 @@ class TradingGUILogicMixin:
                 self.neon_panel.set_status("feed", "red", text)
             if hasattr(self, "api_frame") and hasattr(self.api_frame, "update_market_status"):
                 self.api_frame.update_market_status(False)
+
+    def _update_feed_mode_display(self, ok: bool) -> None:
+        """Update label showing the active data source."""
+        from config import SETTINGS
+
+        mode = SETTINGS.get("data_source_mode", "auto").lower()
+        websocket = getattr(self, "websocket_active", False)
+        if not ok:
+            text = "❌ Kein Feed"
+            color = "red"
+        else:
+            if mode == "websocket":
+                text = "🟢 WebSocket kommt an"
+                color = "green"
+            elif mode == "rest":
+                text = "🔴 REST kommt an"
+                color = "orange"
+            else:  # auto
+                if websocket:
+                    text = "🟢 WebSocket kommt an"
+                    color = "green"
+                else:
+                    text = "🔴 REST kommt an"
+                    color = "orange"
+
+        if hasattr(self, "feed_mode_var"):
+            self.feed_mode_var.set(text)
+        if hasattr(self, "feed_mode_label"):
+            self.feed_mode_label.config(foreground=color)
+        if hasattr(self, "api_frame") and hasattr(self.api_frame, "feed_mode_label"):
+            self.api_frame.feed_mode_label.config(foreground=color)
 
     def update_exchange_status(self, exchange: str, ok: bool) -> None:
         if hasattr(self, "exchange_status_vars") and exchange in self.exchange_status_vars:


### PR DESCRIPTION
## Summary
- track active market data source via `data_source_mode`
- show feed mode label in the credential frame and system status panel
- colorize label to indicate WebSocket or REST usage
- document new GUI indicator in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68730a002b24832a9d7f868104d621b1