### PR TITLE
Stable WebSocket feed with GUI status and fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Handelsergebnisse.
 ## Eigenschaften
 * Preisfeed über **python-binance** (BTCUSDT)
 * Wählbare Marktdatenquelle: REST, WebSocket oder Auto
+* Im **Auto-Modus** wird zuerst der WebSocket-Stream verwendet und bei Problemen
+  automatisch auf REST umgeschaltet
 * Orderausführung über die vorhandene **BitmexTrader**-Klasse
 * Symbolmapping: `BTCUSDT` → `XBTUSD` mittels `bitmex_symbol()`
 * Optionaler Paper-Trading-Modus mit realistischer PnL-Berechnung
@@ -35,6 +37,14 @@ python main.py
 ```
 Die GUI fragt die BitMEX-Zugangsdaten ab und zeigt fortlaufend die Binance-Spot-
 Preise sowie die Entwicklung des Paper-Trading-Kontos an. Über einen Schalter kann jederzeit vom Simulationsmodus in den Live-Betrieb gewechselt werden.
+
+## Datenquellen & Modus
+
+Der Bot kann Binance-Marktdaten über einen WebSocket-Stream oder per REST-API beziehen.
+In der GUI lässt sich der Modus zwischen **WebSocket**, **REST** und **Auto** auswählen.
+Im Auto-Modus versucht der Bot zunächst den WebSocket-Stream und schaltet bei
+Problemen automatisch auf REST um. Der aktuell verwendete Modus ist in der GUI
+jederzeit sichtbar.
 
 ## Trading-Modi: Paper vs. Live
 

--- a/config.py
+++ b/config.py
@@ -12,7 +12,6 @@ SETTINGS = {
     "multiplier": 20,
     "auto_multiplier": False,
     "capital": 1000,
-    "data_source_mode": "rest",  # rest | websocket | auto
     "version": "V10.4_Pro",
     "paper_mode": True,
     # Datenquelle für Marktdaten: websocket | rest | auto

--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -4,7 +4,6 @@ import tkinter as tk
 from tkinter import ttk
 from datetime import datetime
 import logging
-from binance.client import Client
 
 from .trading_gui_logic import TradingGUILogicMixin
 from .api_credential_frame import APICredentialFrame, EXCHANGES
@@ -58,8 +57,6 @@ class TradingGUI(TradingGUILogicMixin):
         StatusDispatcher.on_api_status(self.update_api_status)
         StatusDispatcher.on_feed_status(self.update_feed_status)
 
-        # Binance REST client für Preisabfragen
-        self.binance_client = Client()
 
         from config import SETTINGS
         mode = SETTINGS.get("data_source_mode", "auto").lower()
@@ -536,11 +533,10 @@ class TradingGUI(TradingGUILogicMixin):
 
         symbol = SETTINGS.get("symbol", "BTCUSDT")
 
-        try:
-            ticker = self.binance_client.get_symbol_ticker(symbol=symbol)
-            price = float(ticker["price"])
-        except Exception:
-            price = None
+        from data_provider import fetch_last_price, websocket_active
+
+        price = fetch_last_price("binance", symbol)
+        self.websocket_active = websocket_active()
 
         stamp = datetime.now().strftime("%H:%M:%S")
         line = (

--- a/tests/test_gui_credentials.py
+++ b/tests/test_gui_credentials.py
@@ -25,7 +25,7 @@ class GUICredentialFrameTest(unittest.TestCase):
         except tk.TclError:
             self.skipTest("Tkinter not available")
         frame = APICredentialFrame(root, APICredentialManager())
-        self.assertEqual(frame.data_source_mode.get(), "rest")
+        self.assertEqual(frame.data_source_mode.get(), "auto")
         root.destroy()
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- track WebSocket state in `data_provider`
- show current feed mode in GUI using new helper
- clean up Binance client usage
- document data source modes and default in README
- update tests for new default

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68730fb2bc78832ab39d843ed679d904