### PR TITLE
Update data source handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,16 @@ python main.py
 Die GUI fragt die BitMEX-Zugangsdaten ab und zeigt fortlaufend die Binance-Spot-
 Preise sowie die Entwicklung des Paper-Trading-Kontos an. Über einen Schalter kann jederzeit vom Simulationsmodus in den Live-Betrieb gewechselt werden.
 
-## Datenquellen & Modus
+## 📡 Datenquelle
 
 Der Bot kann Binance-Marktdaten über einen WebSocket-Stream oder per REST-API beziehen.
 In der GUI lässt sich der Modus zwischen **WebSocket**, **REST** und **Auto** auswählen.
-Im Auto-Modus versucht der Bot zunächst den WebSocket-Stream und schaltet bei
-Problemen automatisch auf REST um. Der aktuell verwendete Modus wird in der GUI
-live angezeigt:
+Im Auto-Modus wird zuerst versucht, einen WebSocket aufzubauen. Schlägt das fehl oder bricht die Verbindung ab, stellt der Bot automatisch auf REST um. Läuft der WebSocket bereits, wird er nicht erneut gestartet. Beim Wechsel des Datenmodus wird ein vorhandener Stream vorher mit `twm.stop()` beendet. Der aktuell genutzte Modus wird in der GUI angezeigt:
 
-Der WebSocket wird dabei nur einmal gestartet und bleibt aktiv, bis der Modus geändert wird. Beim Wechsel des Datenmodus werden laufende Streams sauber beendet und bei Bedarf neu aufgebaut. Dadurch werden Konflikte im Eventloop zuverlässig vermieden.
+Der WebSocket wird nur einmal gestartet und bleibt aktiv, bis der Modus geändert wird. Beim Wechsel des Datenmodus werden laufende Streams sauber beendet, damit keine doppelten Verbindungen entstehen.
 
-- **🟢 WebSocket kommt an** – Stream aktiv
-- **🔴 REST kommt an** – Fallback auf REST
+- **🟢 WebSocket aktiv** – Stream aktiv
+- **🔴 REST aktiv** – Fallback auf REST
 
 ## Trading-Modi: Paper vs. Live
 

--- a/gui/api_credential_frame.py
+++ b/gui/api_credential_frame.py
@@ -128,11 +128,14 @@ class APICredentialFrame(ttk.LabelFrame):
     def _on_source_change(self, mode: str) -> None:
         from data_provider import start_websocket, stop_websocket
 
+        prev = SETTINGS.get("data_source_mode", "rest")
         SETTINGS["data_source_mode"] = mode
         symbol = SETTINGS.get("symbol", "BTCUSDT")
-        if mode in {"rest", "auto"}:
+        if prev == "websocket" and mode != "websocket":
             stop_websocket()
         if mode == "websocket":
+            if prev != "websocket":
+                stop_websocket()
             start_websocket(symbol)
 
     def log_price(self, text: str, error: bool = False) -> None:

--- a/gui/trading_gui_logic.py
+++ b/gui/trading_gui_logic.py
@@ -234,17 +234,17 @@ class TradingGUILogicMixin:
             color = "red"
         else:
             if mode == "websocket":
-                text = "🟢 WebSocket kommt an"
+                text = "🟢 WebSocket aktiv"
                 color = "green"
             elif mode == "rest":
-                text = "🔴 REST kommt an"
+                text = "🔴 REST aktiv"
                 color = "orange"
             else:  # auto
                 if websocket:
-                    text = "🟢 WebSocket kommt an"
+                    text = "🟢 WebSocket aktiv"
                     color = "green"
                 else:
-                    text = "🔴 REST kommt an"
+                    text = "🔴 REST aktiv"
                     color = "orange"
 
         if hasattr(self, "feed_mode_var"):


### PR DESCRIPTION
## Summary
- manage ThreadedWebsocketManager only once and expose `price_var`
- stop existing WebSocket stream when mode changes
- show `WebSocket aktiv` / `REST aktiv` in GUI
- document how data source switching works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68731afb5fb0832ab1aef9c2f1af0736