### PR TITLE
Enable live price display with stable Binance websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Der WebSocket wird nur einmal gestartet und bleibt aktiv, bis der Modus geänder
 - **🟢 WebSocket aktiv** – Stream aktiv
 - **🔴 REST aktiv** – Fallback auf REST
 
+### 📡 Datenquelle: Binance BTCUSDT (Spot)
+Der EntryMaster-Bot nutzt immer BTCUSDT-Marktdaten von Binance Spot (nicht Futures). Der Preisfeed erfolgt standardmäßig über WebSocket für Echtzeit-Ticks. Sollte dieser ausfallen, greift der Bot automatisch auf REST zurück. Der Benutzer kann im GUI-Feld bei der API-Konfiguration manuell auswählen:
+
+- **Auto** → versucht WebSocket, fällt zurück auf REST
+- **WebSocket** → erzwingt Echtzeit-Ticks
+- **REST** → fallback-only (z. B. bei Netzrestriktionen)
+
+Wichtig: Der Preisfeed wird niemals über andere Börsen gespeist. BitMEX dient nur zur Orderausführung bei Live-Trading.
+
 ## Trading-Modi: Paper vs. Live
 
 - **Einstieg & Ausstieg erfolgen immer anhand echter Binance BTCUSDT Marktdaten**

--- a/gui/api_credential_frame.py
+++ b/gui/api_credential_frame.py
@@ -131,11 +131,12 @@ class APICredentialFrame(ttk.LabelFrame):
         prev = SETTINGS.get("data_source_mode", "rest")
         SETTINGS["data_source_mode"] = mode
         symbol = SETTINGS.get("symbol", "BTCUSDT")
-        if prev == "websocket" and mode != "websocket":
-            stop_websocket()
-        if mode == "websocket":
-            if prev != "websocket":
+
+        if mode == "rest":
+            if prev in {"websocket", "auto"}:
                 stop_websocket()
+        else:  # websocket or auto
+            stop_websocket()
             start_websocket(symbol)
 
     def log_price(self, text: str, error: bool = False) -> None:

--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -226,6 +226,11 @@ class TradingGUI(TradingGUILogicMixin):
         ).pack(side="left")
         self._on_mode_toggle()
 
+        # Preis-Anzeige oben rechts
+        from data_provider import price_var
+        self.price_label = ttk.Label(top_info, textvariable=price_var, foreground="blue", font=("Arial", 11, "bold"))
+        self.price_label.pack(side="right", padx=10)
+
         # --- Hauptcontainer ---
         container = ttk.Frame(self.main_frame)
         container.pack(padx=10, pady=5)


### PR DESCRIPTION
## Summary
- show BTCUSDT price in the GUI
- manage websocket lifecycle when switching data modes
- add explanation about the Binance spot feed to the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68732032f898832a9deaffce0af275ca