### PR TITLE
Fix WebSocket init and Tk StringVar timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Preise sowie die Entwicklung des Paper-Trading-Kontos an. Über einen Schalter k
 
 ## 📡 Datenquelle
 
+Der EntryMaster Bot nutzt WebSocket-Preisdaten von Binance BTCUSDT. Bei Fehler erfolgt ein automatischer Fallback auf REST. Die Quelle wird live in der GUI angezeigt. Die WebSocket-Verbindung ist stabil, einmalig und kollisionsfrei mit der Tkinter-Oberfläche integriert.
+
 Der Bot kann Binance-Marktdaten über einen WebSocket-Stream oder per REST-API beziehen.
 In der GUI lässt sich der Modus zwischen **WebSocket**, **REST** und **Auto** auswählen.
 Im Auto-Modus wird zuerst versucht, einen WebSocket aufzubauen. Schlägt das fehl oder bricht die Verbindung ab, stellt der Bot automatisch auf REST um. Läuft der WebSocket bereits, wird er nicht erneut gestartet. Beim Wechsel des Datenmodus wird ein vorhandener Stream vorher mit `twm.stop()` beendet. Der aktuell genutzte Modus wird in der GUI angezeigt:

--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -227,7 +227,8 @@ class TradingGUI(TradingGUILogicMixin):
         self._on_mode_toggle()
 
         # Preis-Anzeige oben rechts
-        from data_provider import price_var
+        from data_provider import init_price_var, price_var
+        init_price_var(self.root)
         self.price_label = ttk.Label(top_info, textvariable=price_var, foreground="blue", font=("Arial", 11, "bold"))
         self.price_label.pack(side="right", padx=10)
 


### PR DESCRIPTION
## Summary
- create `init_price_var` so Tk variables are initialized only after `Tk()`
- prevent duplicate WebSocket threads and handle restart cleanly
- display price in GUI after initializing Tk variable
- document Binance WebSocket behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873237a75d4832a9d63f4add8bfe5f8