### PR TITLE
Fix price_var init for Tkinter WebSocket updates

### DIFF
--- a/main.py
+++ b/main.py
@@ -139,7 +139,10 @@ def main():
     init_price_var(root)
 
     def update_price(p):
-        root.after(0, lambda: price_var.set(p))
+        if price_var is not None:
+            root.after(0, lambda val=p: price_var.set(val))
+        else:
+            print("[WebSocket] ❌ price_var ist nicht initialisiert")
 
     ws = BinanceWebSocket(update_price)
     ws.start()


### PR DESCRIPTION
## Summary
- ensure Tk root exists for price_var initialization
- update websocket callback to run on the Tk thread and warn if `price_var` is missing
- adjust main websocket price handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68732fbf8194832a9061f05f2f8f53f9