### PR TITLE
Fix price var init and websocket

### DIFF
--- a/data_provider.py
+++ b/data_provider.py
@@ -63,8 +63,8 @@ def start_websocket(symbol: str = "BTCUSDT") -> None:
             p = float(price)
             _WS_PRICE[symbol] = p
             _WEBSOCKET_RUNNING = True
-            if price_var is not None and price_var.master is not None:
-                price_var.master.after(0, lambda val=price: price_var.set(str(val)))
+            if price_var is not None and _TK_ROOT is not None:
+                _TK_ROOT.after(0, lambda val=price: price_var.set(str(val)))
             else:
                 print("[WebSocket] \u274c price_var ist nicht initialisiert")
             try:
@@ -143,8 +143,8 @@ def fetch_last_price(exchange: str = "binance", symbol: Optional[str] = None) ->
         data = _BINANCE.get_symbol_ticker(symbol=pair)
         price = float(data["price"])
         logging.debug("Price update %s: %.2f", pair, price)
-        if price_var is not None and price_var.master is not None:
-            price_var.master.after(0, lambda val=price: price_var.set(str(val)))
+        if price_var is not None and _TK_ROOT is not None:
+            _TK_ROOT.after(0, lambda val=price: price_var.set(str(val)))
         return price
     except Exception as exc:
         logging.debug("Failed to fetch %s: %s", pair, exc)

--- a/main.py
+++ b/main.py
@@ -23,7 +23,12 @@ from gui_bridge import GUIBridge
 from realtime_runner import run_bot_live
 from global_state import entry_time_global, ema_trend_global, atr_value_global
 from binance_ws import BinanceWebSocket
-from data_provider import init_price_var, price_var
+import data_provider
+
+# Tk root and shared price variable
+root = tk.Tk()
+data_provider.init_price_var(root)
+price_var = data_provider.price_var
 
 init(autoreset=True)
 setup_logging()
@@ -135,14 +140,12 @@ def on_gui_start(gui):
 def main():
     load_settings_from_file()
     detect_available_exchanges(SETTINGS)
-    root = tk.Tk()
-    init_price_var(root)
 
     def update_price(p):
-        if price_var is not None:
-            root.after(0, lambda val=p: price_var.set(val))
-        else:
-            print("[WebSocket] ❌ price_var ist nicht initialisiert")
+        try:
+            root.after(0, lambda: price_var.set(p))
+        except Exception as e:
+            print("❌ WebSocket Fehler:", e)
 
     ws = BinanceWebSocket(update_price)
     ws.start()


### PR DESCRIPTION
## Summary
- initialize Tk root and `price_var` at module load
- use `root.after` when updating price
- remove direct `.master` access in `data_provider`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873322caf38832abba6ab5dfae8ef13