### PR TITLE
Implement stable data feed switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,20 @@ Der WebSocket wird nur einmal gestartet und bleibt aktiv, bis der Modus geänder
 - **🟢 WebSocket aktiv** – Stream aktiv
 - **🔴 REST aktiv** – Fallback auf REST
 
+## Live-Daten-Handling
+
+### 📡 Datenquellen (Binance BTCUSDT)
+- Der Bot unterstützt **zwei Datenquellen** für Marktdaten:
+  - WebSocket (schnell, zuverlässig, ohne Auth)
+  - REST-API (Fallback bei Verbindungsproblemen)
+
+- Über die GUI kann per Schalter umgeschaltet werden zwischen:
+  - `Auto` (empfohlen): bevorzugt WebSocket, wechselt bei Problemen zu REST
+  - `WebSocket`: nutzt ausschließlich Live-Stream
+  - `REST`: nutzt zyklischen Abruf alle 1s
+
+- Die aktive Datenquelle wird in der GUI angezeigt. Konflikte werden intern gelöst. **Es ist immer nur eine Datenquelle gleichzeitig aktiv.**
+
 ### 📡 Datenquelle: Binance BTCUSDT (Spot)
 Der EntryMaster-Bot nutzt immer BTCUSDT-Marktdaten von Binance Spot (nicht Futures). Der Preisfeed erfolgt standardmäßig über WebSocket für Echtzeit-Ticks. Sollte dieser ausfallen, greift der Bot automatisch auf REST zurück. Der Benutzer kann im GUI-Feld bei der API-Konfiguration manuell auswählen:
 

--- a/binance_ws.py
+++ b/binance_ws.py
@@ -2,15 +2,17 @@ from websocket import WebSocketApp
 import threading
 import json
 
+
 class BinanceWebSocket:
     def __init__(self, on_price):
         self.on_price = on_price
-        self.thread = threading.Thread(target=self._start_socket, daemon=True)
+        self.thread: threading.Thread | None = None
+        self.ws: WebSocketApp | None = None
 
     def _start_socket(self):
         socket = "wss://stream.binance.com:9443/ws/btcusdt@trade"
-        ws = WebSocketApp(socket, on_message=self._on_message)
-        ws.run_forever()
+        self.ws = WebSocketApp(socket, on_message=self._on_message)
+        self.ws.run_forever()
 
     def _on_message(self, ws, message):
         try:
@@ -22,4 +24,16 @@ class BinanceWebSocket:
             print("WebSocket Fehler:", e)
 
     def start(self):
+        if self.thread and self.thread.is_alive():
+            return
+        self.thread = threading.Thread(target=self._start_socket, daemon=True)
         self.thread.start()
+
+    def stop(self):
+        if self.ws is not None:
+            try:
+                self.ws.close()
+            except Exception:
+                pass
+        if self.thread and self.thread.is_alive():
+            self.thread.join(timeout=1)

--- a/data_provider.py
+++ b/data_provider.py
@@ -20,6 +20,9 @@ from tkinter import Tk, StringVar
 
 from config import SETTINGS
 
+# Currently active feed source: websocket | rest | auto
+current_feed_source = SETTINGS.get("data_source_mode", "auto").lower()
+
 _BINANCE = Client("", "")
 # WebSocket manager and price cache used when ``data_source_mode`` is
 # set to ``websocket`` or ``auto``.
@@ -31,6 +34,14 @@ _WS_STARTED: bool = False
 
 # Tk root used for Tkinter variables when none is provided
 _TK_ROOT: Tk | None = None
+
+# REST polling handle
+_REST_JOB: str | None = None
+_REST_INTERVAL_MS = 1000
+_REST_RUNNING = False
+
+# Auto mode watchdog
+_AUTO_JOB: str | None = None
 
 # Tkinter variable updated by the WebSocket callback
 price_var: StringVar | None = None
@@ -81,6 +92,20 @@ def start_websocket(symbol: str = "BTCUSDT") -> None:
     print("✅ WebSocket verbunden: Binance BTCUSDT")
 
 
+def stop_websocket() -> None:
+    """Stop the running websocket connection if active."""
+    global _WS_CLIENT, _WS_STARTED, _WEBSOCKET_RUNNING
+    if _WS_CLIENT is None:
+        return
+    try:
+        _WS_CLIENT.stop()
+    except Exception:
+        pass
+    _WS_CLIENT = None
+    _WS_STARTED = False
+    _WEBSOCKET_RUNNING = False
+
+
 def is_websocket_running() -> bool:
     """Return ``True`` if the websocket manager is active."""
     return _WEBSOCKET_RUNNING
@@ -90,6 +115,107 @@ def websocket_active() -> bool:
     """Return ``True`` if a websocket stream is delivering prices."""
     return _WEBSOCKET_RUNNING
 
+
+def _rest_poll(symbol: str, interval: str) -> None:
+    global _REST_JOB, _REST_RUNNING
+    if _TK_ROOT is None:
+        init_price_var()
+    pair = _normalize_symbol(symbol)
+    try:
+        data = _BINANCE.get_symbol_ticker(symbol=pair)
+        price = float(data["price"])
+        _WS_PRICE[symbol] = price
+        if price_var is not None and _TK_ROOT is not None:
+            _TK_ROOT.after(0, lambda val=price: price_var.set(str(val)))
+        try:
+            import global_state
+            global_state.last_feed_time = time.time()
+        except Exception:
+            pass
+    except Exception:
+        pass
+    if _TK_ROOT is not None:
+        _REST_JOB = _TK_ROOT.after(_REST_INTERVAL_MS, _rest_poll, symbol, interval)
+    _REST_RUNNING = True
+
+
+def start_rest_timer(symbol: str = "BTCUSDT", interval: str = "1m") -> None:
+    global _REST_RUNNING
+    if _REST_RUNNING:
+        return
+    if _TK_ROOT is None:
+        init_price_var()
+    _rest_poll(symbol, interval)
+
+
+def cancel_rest_timer() -> None:
+    global _REST_JOB, _REST_RUNNING
+    if _REST_JOB and _TK_ROOT is not None:
+        try:
+            _TK_ROOT.after_cancel(_REST_JOB)
+        except Exception:
+            pass
+    _REST_JOB = None
+    _REST_RUNNING = False
+
+
+def _auto_loop(symbol: str, interval: str, timeout: int = 5) -> None:
+    global _AUTO_JOB
+    if _TK_ROOT is None:
+        init_price_var()
+    ws_ok = websocket_active()
+    last = None
+    try:
+        import global_state
+        last = global_state.last_feed_time
+    except Exception:
+        pass
+    if ws_ok:
+        cancel_rest_timer()
+    else:
+        if last is None or time.time() - last > timeout:
+            start_rest_timer(symbol, interval)
+    if _TK_ROOT is not None:
+        _AUTO_JOB = _TK_ROOT.after(1000, _auto_loop, symbol, interval, timeout)
+
+
+def stop_auto_mode() -> None:
+    global _AUTO_JOB
+    if _AUTO_JOB and _TK_ROOT is not None:
+        try:
+            _TK_ROOT.after_cancel(_AUTO_JOB)
+        except Exception:
+            pass
+    _AUTO_JOB = None
+    cancel_rest_timer()
+    stop_websocket()
+
+
+def start_auto_mode(symbol: str = "BTCUSDT", interval: str = "1m") -> None:
+    start_websocket(symbol)
+    _auto_loop(symbol, interval)
+
+
+def switch_feed_source(mode: str, symbol: str = "BTCUSDT", interval: str = "1m") -> None:
+    """Switch active data source ensuring only one is running."""
+    global current_feed_source
+    if mode == current_feed_source:
+        return
+    if current_feed_source == "websocket":
+        stop_websocket()
+    elif current_feed_source == "rest":
+        cancel_rest_timer()
+    elif current_feed_source == "auto":
+        stop_auto_mode()
+
+    current_feed_source = mode
+    SETTINGS["data_source_mode"] = mode
+    if mode == "websocket":
+        start_websocket(symbol)
+    elif mode == "rest":
+        start_rest_timer(symbol, interval)
+    else:
+        start_auto_mode(symbol, interval)
 
 
 
@@ -130,7 +256,7 @@ def fetch_last_price(exchange: str = "binance", symbol: Optional[str] = None) ->
         return None
 
     pair = _normalize_symbol(symbol or "BTCUSDT")
-    mode = SETTINGS.get("data_source_mode", "rest").lower()
+    mode = current_feed_source
 
     if mode in {"websocket", "auto"}:
         price = _fetch_ws_price(pair)
@@ -159,7 +285,7 @@ def get_latest_candle_batch(
 def get_live_candles(symbol: str, interval: str, limit: int) -> List[Candle]:
     """Retrieve recent candles from Binance Spot."""
     pair = _normalize_symbol(symbol)
-    mode = SETTINGS.get("data_source_mode", "rest").lower()
+    mode = current_feed_source
 
     if mode in {"websocket", "auto"}:
         # placeholder: websocket candle feed not yet implemented

--- a/gui/api_credential_frame.py
+++ b/gui/api_credential_frame.py
@@ -126,13 +126,12 @@ class APICredentialFrame(ttk.LabelFrame):
         self.check_market_feed()
 
     def _on_source_change(self, mode: str) -> None:
-        from data_provider import start_websocket
+        from data_provider import switch_feed_source
 
         SETTINGS["data_source_mode"] = mode
         symbol = SETTINGS.get("symbol", "BTCUSDT")
 
-        if mode != "rest":
-            start_websocket(symbol)
+        switch_feed_source(mode, symbol)
 
     def log_price(self, text: str, error: bool = False) -> None:
         color = "red" if error else "green"

--- a/gui/trading_gui_logic.py
+++ b/gui/trading_gui_logic.py
@@ -225,27 +225,26 @@ class TradingGUILogicMixin:
 
     def _update_feed_mode_display(self, ok: bool) -> None:
         """Update label showing the active data source."""
-        from config import SETTINGS
-
-        mode = SETTINGS.get("data_source_mode", "auto").lower()
+        from data_provider import current_feed_source
         websocket = getattr(self, "websocket_active", False)
+        mode = current_feed_source
         if not ok:
             text = "❌ Kein Feed"
             color = "red"
         else:
             if mode == "websocket":
-                text = "🟢 WebSocket aktiv"
+                text = "WebSocket kommt an"
                 color = "green"
             elif mode == "rest":
-                text = "🔴 REST aktiv"
-                color = "orange"
+                text = "REST kommt an"
+                color = "red"
             else:  # auto
                 if websocket:
-                    text = "🟢 WebSocket aktiv"
+                    text = "WebSocket kommt an"
                     color = "green"
                 else:
-                    text = "🔴 REST aktiv"
-                    color = "orange"
+                    text = "REST kommt an"
+                    color = "red"
 
         if hasattr(self, "feed_mode_var"):
             self.feed_mode_var.set(text)


### PR DESCRIPTION
## Summary
- add stop() to `BinanceWebSocket`
- manage active feed source in `data_provider` with WebSocket/REST/auto control
- update API credential frame to use the new switching logic
- show active feed status with green/red label texts
- document available data sources in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68733681707c832ab224fa0d98f68d42