### PR TITLE
Implement Binance candle websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Handelslogik basiert auf einem TradingView-Indikator und läuft wahlweise im Liv
 Handelsergebnisse.
 
 ## Eigenschaften
-* Preisfeed ausschließlich über **python-binance** WebSocket (BTCUSDT)
+* Preis- und Candlefeed ausschließlich über **python-binance** WebSocket (BTCUSDT)
+* Der Bot empfängt 1-Minuten-Candles via `btcusdt@kline_1m` und zeigt nur abgeschlossene Kerzen an. REST wurde komplett entfernt.
 * Orderausführung über die vorhandene **BitmexTrader**-Klasse
 * Symbolmapping: `BTCUSDT` → `XBTUSD` mittels `bitmex_symbol()`
 * Optionaler Paper-Trading-Modus mit realistischer PnL-Berechnung
@@ -40,12 +41,12 @@ Preise sowie die Entwicklung des Paper-Trading-Kontos an. Über einen Schalter k
 
 ## 📡 Datenquelle
 
-Der EntryMaster Bot nutzt WebSocket-Preisdaten von Binance BTCUSDT.
+Der EntryMaster Bot nutzt WebSocket-Preisdaten und 1m-Candle-Daten von Binance BTCUSDT.
 
 Dieser Bot arbeitet ausschließlich mit Live-Marktdaten von Binance BTCUSDT über
 die WebSocket-API. REST-Zugriffe wurden entfernt, um maximale
-Echtzeitpräzision zu gewährleisten. Der Preisfeed wird niemals über andere
-Börsen gespeist. BitMEX dient nur zur Orderausführung bei Live-Trading.
+Echtzeitpräzision zu gewährleisten. Sowohl Preis- als auch Candle-Daten werden nur per WebSocket bezogen.
+Der Preisfeed wird niemals über andere Börsen gespeist. BitMEX dient nur zur Orderausführung bei Live-Trading.
 
 ## Trading-Modi: Paper vs. Live
 

--- a/binance_ws.py
+++ b/binance_ws.py
@@ -37,3 +37,53 @@ class BinanceWebSocket:
                 pass
         if self.thread and self.thread.is_alive():
             self.thread.join(timeout=1)
+
+
+class BinanceCandleWebSocket:
+    """WebSocket manager for Binance candle streams."""
+
+    def __init__(self, on_candle):
+        self.on_candle = on_candle
+        self.thread: threading.Thread | None = None
+        self.ws: WebSocketApp | None = None
+        self._warning_printed = False
+
+    def _start_socket(self):
+        socket = "wss://stream.binance.com:9443/ws/btcusdt@kline_1m"
+        self.ws = WebSocketApp(socket, on_message=self._on_message)
+        self.ws.run_forever()
+
+    def _on_message(self, ws, message):
+        try:
+            data = json.loads(message)
+            k = data.get("k")
+            if not k or not k.get("x"):
+                return
+            candle = {
+                "timestamp": k.get("t"),
+                "open": float(k.get("o")),
+                "high": float(k.get("h")),
+                "low": float(k.get("l")),
+                "close": float(k.get("c")),
+                "volume": float(k.get("v")),
+            }
+            self.on_candle(candle)
+        except Exception as e:
+            if not self._warning_printed:
+                print("⚠️ Candle-Daten unvollständig oder fehlerhaft", e)
+                self._warning_printed = True
+
+    def start(self):
+        if self.thread and self.thread.is_alive():
+            return
+        self.thread = threading.Thread(target=self._start_socket, daemon=True)
+        self.thread.start()
+
+    def stop(self):
+        if self.ws is not None:
+            try:
+                self.ws.close()
+            except Exception:
+                pass
+        if self.thread and self.thread.is_alive():
+            self.thread.join(timeout=1)


### PR DESCRIPTION
## Summary
- build a dedicated `BinanceCandleWebSocket` class
- stream 1m candle data via websocket in `data_provider`
- store received candles and update global feed status
- mention websocket-only candle feed in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68733e81d04c832aa2b94e372fbe56bd