### PR TITLE
Fix WebSocket candles

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,21 @@ die WebSocket-API. REST-Zugriffe wurden entfernt, um maximale
 Echtzeitpräzision zu gewährleisten. Sowohl Preis- als auch Candle-Daten werden nur per WebSocket bezogen.
 Der Preisfeed wird niemals über andere Börsen gespeist. BitMEX dient nur zur Orderausführung bei Live-Trading.
 
+### 📡 WebSocket-only Betrieb
+
+Der Bot nutzt **ausschließlich WebSocket** für Binance BTCUSDT Marktdaten.
+REST wurde entfernt, um saubere Candle-Daten sicherzustellen.
+
+- ✅ Stream: `kline_1m`
+- ✅ Nur abgeschlossene Candles (`x == True`) werden verarbeitet
+- ✅ Anzeige in GUI + Log: "Marktdaten kommen an"
+
+#### ⚠️ Hinweise
+- Wenn keine Candle-Daten angezeigt werden, prüfe:
+  - Verbindung zur Binance API
+  - Ob der `kline`-Stream verwendet wird und nicht `@trade`
+  - Ob `kline['x'] == True` korrekt überprüft wird
+
 ## Trading-Modi: Paper vs. Live
 
 - **Einstieg & Ausstieg erfolgen immer anhand echter Binance BTCUSDT Marktdaten**

--- a/data_provider.py
+++ b/data_provider.py
@@ -12,17 +12,17 @@ from typing import List, Optional, TypedDict
 
 import time
 
-from binance_ws import BinanceWebSocket, BinanceCandleWebSocket
+import binance_ws
 from tkinter import Tk, StringVar
 
 
 # WebSocket manager and price cache
-_WS_CLIENT: BinanceWebSocket | None = None
+_WS_CLIENT: binance_ws.BinanceWebSocket | None = None
 _WS_PRICE: dict[str, float] = {}
 _WEBSOCKET_RUNNING: bool = False
 
 _WS_STARTED: bool = False
-_CANDLE_WS_CLIENT: BinanceCandleWebSocket | None = None
+_CANDLE_WS_CLIENT: binance_ws.BinanceCandleWebSocket | None = None
 _CANDLE_WS_STARTED: bool = False
 _WS_CANDLES: list["Candle"] = []
 _CANDLE_WARNING_SHOWN: bool = False
@@ -74,7 +74,7 @@ def start_websocket(symbol: str = "BTCUSDT") -> None:
         except Exception as e:  # pragma: no cover - just log
             print("❌ WebSocket Fehler", e)
 
-    _WS_CLIENT = BinanceWebSocket(handle)
+    _WS_CLIENT = binance_ws.BinanceWebSocket(handle)
     _WS_CLIENT.start()
     _WS_STARTED = True
     print("✅ WebSocket verbunden: Binance BTCUSDT")
@@ -108,7 +108,8 @@ def start_candle_websocket(symbol: str = "BTCUSDT", interval: str = "1m") -> Non
             f"✅ Candle empfangen: Open={candle['open']}, Close={candle['close']}, Vol={candle['volume']}"
         )
 
-    _CANDLE_WS_CLIENT = BinanceCandleWebSocket(handle)
+    binance_ws.on_candle_callback = handle
+    _CANDLE_WS_CLIENT = binance_ws.BinanceCandleWebSocket(handle)
     _CANDLE_WS_CLIENT.start()
     _CANDLE_WS_STARTED = True
 
@@ -134,6 +135,11 @@ def is_websocket_running() -> bool:
 def websocket_active() -> bool:
     """Return ``True`` if a websocket stream is delivering prices."""
     return _WEBSOCKET_RUNNING
+
+
+def get_last_candle_time() -> Optional[float]:
+    """Return the timestamp of the most recent closed candle."""
+    return binance_ws.last_candle_time
 
 
 

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -11,7 +11,7 @@ import time
 import traceback
 from datetime import datetime
 
-from data_provider import fetch_latest_candle, fetch_last_price
+from data_provider import fetch_latest_candle, fetch_last_price, get_last_candle_time
 from cooldown_manager import CooldownManager
 from session_filter import SessionFilter
 from status_block import print_entry_status
@@ -181,7 +181,9 @@ def run_bot_live(settings=None, app=None):
             if price is None and hasattr(app, "log_event"):
                 app.log_event("Keine Marktdaten – Exchange: BINANCE")
             if not candle:
-                print("⚠️ Keine Candle-Daten.")
+                last_candle = get_last_candle_time()
+                if last_candle is None or time.time() - last_candle > 5:
+                    print("⚠️ Keine Candle-Daten.")
                 time.sleep(1)
                 continue
 


### PR DESCRIPTION
## Summary
- stream closed candles from Binance via `btcusdt@kline_1m`
- expose global `on_candle_callback` and `last_candle_time`
- route candle callback through `data_provider`
- warn about missing candles only after 5 seconds
- document WebSocket-only mode in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873412bfe04832a88a9342233d6d78b