### PR TITLE
Handle incomplete candles safely

### DIFF
--- a/data_provider.py
+++ b/data_provider.py
@@ -217,6 +217,16 @@ def get_live_candles(symbol: str, interval: str, limit: int) -> List[Candle]:
 
 
 def fetch_latest_candle(symbol: str = "BTCUSDT", interval: str = "1m") -> Optional[Candle]:
-    """Convenience helper returning only the latest candle."""
+    """Convenience helper returning only the latest candle.
+
+    Checks that the returned candle contains complete OHLCV data. If the
+    candle is incomplete, ``None`` is returned and a warning is logged.
+    """
     candles = get_latest_candle_batch(symbol, interval, 1)
-    return candles[-1] if candles else None
+    candle = candles[-1] if candles else None
+    if candle and not all(
+        k in candle and candle[k] is not None for k in ("open", "high", "low", "close", "volume")
+    ):
+        logging.warning("fetch_latest_candle: incomplete data %s", candle)
+        return None
+    return candle

--- a/indicator_utils.py
+++ b/indicator_utils.py
@@ -33,7 +33,14 @@ def calculate_atr(candles, length):
     📏 Berechnet den Average True Range (ATR) basierend auf Candle-Daten.
     Erwartet: [{'high': ..., 'low': ..., 'close': ...}, ...]
     """
+    candles = [
+        c
+        for c in candles
+        if all(k in c and c[k] is not None for k in ("high", "low", "close"))
+    ]
     if not candles or len(candles) < length:
+        if len(candles) < 3:
+            print("⚠️ Zu wenige valide Candles für ATR")
         return None
 
     trs = []

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -185,6 +185,14 @@ def run_bot_live(settings=None, app=None):
             else:
                 candle_warning_printed = False
 
+            if not all(
+                k in candle and candle[k] is not None
+                for k in ("open", "high", "low", "close", "volume")
+            ):
+                print("⚠️ Candle-Daten unvollständig oder fehlerhaft", candle)
+                time.sleep(1)
+                continue
+
             # Update global timestamp for feed watchdog
             global_state.last_feed_time = time.time()
 


### PR DESCRIPTION
## Summary
- skip invalid candles in realtime runner
- ignore incomplete rows in ATR calculation
- validate candles in `fetch_latest_candle`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68735091c4f4832a91338f345cd87513