### PR TITLE
Fix duplicate candle callback and restore full candle data

### DIFF
--- a/binance_ws.py
+++ b/binance_ws.py
@@ -2,10 +2,9 @@ from websocket import WebSocketApp
 import threading
 import json
 import time
-from typing import Callable, Optional
+from typing import Callable
 
-on_candle_callback: Optional[Callable[[dict], None]] = None
-last_candle_time: Optional[float] = None
+last_candle_time: float | None = None
 
 
 class BinanceWebSocket:
@@ -89,14 +88,7 @@ class BinanceCandleWebSocket:
             print(
                 f"✅ Candle abgeschlossen: Open={candle['open']}, Close={candle['close']}"
             )
-            if on_candle_callback:
-                on_candle_callback(
-                    {
-                        "timestamp": candle["timestamp"],
-                        "open": candle["open"],
-                        "close": candle["close"],
-                    }
-                )
+            # forward the complete candle to the callback only once
             self.on_candle(candle)
         except Exception as e:
             if not self._warning_printed:

--- a/data_provider.py
+++ b/data_provider.py
@@ -25,7 +25,6 @@ _WS_STARTED: bool = False
 _CANDLE_WS_CLIENT: binance_ws.BinanceCandleWebSocket | None = None
 _CANDLE_WS_STARTED: bool = False
 _WS_CANDLES: list["Candle"] = []
-_CANDLE_CACHE: "Candle" | None = None
 _CANDLE_WARNING_SHOWN: bool = False
 
 # Tk root used for Tkinter variables when none is provided
@@ -109,7 +108,7 @@ def start_candle_websocket(symbol: str = "BTCUSDT", interval: str = "1m") -> Non
             f"✅ Candle empfangen: Open={candle['open']}, Close={candle['close']}, Vol={candle['volume']}"
         )
 
-    binance_ws.on_candle_callback = handle
+    # pass the handler directly to the websocket; no additional callback needed
     _CANDLE_WS_CLIENT = binance_ws.BinanceCandleWebSocket(handle, symbol=symbol, interval=interval)
     _CANDLE_WS_CLIENT.start()
     _CANDLE_WS_STARTED = True
@@ -171,11 +170,10 @@ class Candle(TypedDict):
 
 def update_candle_feed(candle: Candle) -> None:
     """Store *candle* in the internal cache and update feed timestamp."""
-    global _WS_CANDLES, _WEBSOCKET_RUNNING, _CANDLE_CACHE
+    global _WS_CANDLES, _WEBSOCKET_RUNNING
     _WS_CANDLES.append(candle)
     if len(_WS_CANDLES) > 1000:
         _WS_CANDLES.pop(0)
-    _CANDLE_CACHE = candle
     _WEBSOCKET_RUNNING = True
     try:
         import global_state


### PR DESCRIPTION
## Summary
- remove truncated candle callback in `binance_ws`
- pass full candle data once via `BinanceCandleWebSocket`
- simplify candle cache logic in `data_provider`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873603b7bd8832a857709471a1e8a93