### PR TITLE
Fix indentation in manual SL toggle

### DIFF
--- a/gui/trading_gui_logic.py
+++ b/gui/trading_gui_logic.py
@@ -390,7 +390,8 @@ class TradingGUILogicMixin:
         except Exception:
             self.sl_tp_manual_active.set(False)
             if hasattr(self, "manual_sl_button"):
-            self.manual_sl_button.config(fg="red")
+                # Button rot einfärben, um ungültige Eingabe zu signalisieren
+                self.manual_sl_button.config(fg="red")
             self.log_event("❌ Ungültige manuelle SL/TP Werte")
             return
 


### PR DESCRIPTION
## Summary
- fix mis-indented `if` block in `toggle_manual_sl_tp`

## Testing
- `pytest -q`
- `python -m py_compile gui/trading_gui_logic.py`


------
https://chatgpt.com/codex/tasks/task_b_687367cb7168832abfd28705ccf73909