### PR TITLE
Fix feed monitoring and websocket startup

### DIFF
--- a/binance_ws.py
+++ b/binance_ws.py
@@ -114,8 +114,8 @@ class BinanceCandleWebSocket:
                 import global_state
 
                 global_state.last_feed_time = time.time()
-            except Exception:
-                pass
+            except Exception as e:
+                print("❌ Fehler beim Setzen von last_feed_time:", e)
 
             if self.on_candle:
                 # forward the candle to optional callback for further processing

--- a/data_provider.py
+++ b/data_provider.py
@@ -103,6 +103,7 @@ def start_candle_websocket(symbol: str = "BTCUSDT", interval: str = "1m") -> Non
     """Start candle websocket feed for *symbol* and *interval*."""
     global _CANDLE_WS_STARTED, _CANDLE_WS_CLIENT, _CANDLE_SYMBOL, _CANDLE_INTERVAL
     if _CANDLE_WS_STARTED:
+        print("⚠️ Candle-WebSocket bereits gestartet.")
         return
 
     print("INFO WebSocket Candle-Stream gestartet")
@@ -157,9 +158,10 @@ def _monitor_loop() -> None:
     global _FEED_MONITOR_STARTED
     while _FEED_MONITOR_STARTED:
         try:
-            last_ts = get_last_candle_time()
-            if last_ts is None or time.time() - last_ts > 25:
-                print("⚠️ Kein Candle-Update seit 25s – versuche Neustart")
+            import global_state
+            last_ts = global_state.last_feed_time
+            if last_ts is None or time.time() - last_ts > 30:
+                print("❌ Feed tot – versuche Neustart")
                 stop_candle_websocket()
                 start_candle_websocket(_CANDLE_SYMBOL, _CANDLE_INTERVAL)
             else:

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -16,6 +16,7 @@ from data_provider import (
     fetch_last_price,
     get_last_candle_time,
     get_live_candles,
+    start_candle_websocket,
 )
 from cooldown_manager import CooldownManager
 from session_filter import SessionFilter
@@ -97,6 +98,9 @@ def run_bot_live(settings=None, app=None):
     start_capital = capital
 
     print_start_banner(capital)
+
+    # sicherstellen, dass der Candle-Feed laeuft
+    start_candle_websocket(settings["symbol"], settings.get("interval", "1m"))
 
     if app:
         settings["log_event"] = app.log_event
@@ -184,6 +188,10 @@ def run_bot_live(settings=None, app=None):
             time.sleep(1)
             continue
         if not getattr(app, "feed_ok", True):
+            import global_state
+            print(
+                f"🧪 Letzter Feed-Eingang vor {time.time() - global_state.last_feed_time:.1f} Sekunden"
+            )
             time.sleep(1)
             continue
         risk_manager.update_capital(capital)


### PR DESCRIPTION
## Summary
- update feed timestamp logging when candles arrive
- warn when candle websocket already started and prevent duplicates
- tighten candle feed monitor using `global_state.last_feed_time`
- start candle websocket before trading loop and log last feed delay for debugging

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68737e4bbc44832a9d561f9a193dd8a6