### PR TITLE
Fix websocket emoji print error

### DIFF
--- a/binance_ws.py
+++ b/binance_ws.py
@@ -87,7 +87,8 @@ class BinanceCandleWebSocket(BaseWebSocket):
 
     def _on_message(self, ws, message):
         """Handle incoming kline messages and forward completed candles."""
-        print("\ud83d\udce5 Raw:", message)
+        # Use actual emoji character to avoid encoding issues on some systems
+        print("📥 Raw:", message)
         global last_candle_time
         try:
             data = json.loads(message)


### PR DESCRIPTION
## Summary
- handle candle websocket messages without surrogate pair encoding issues

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687394428b14832a81bf4cc144dc01eb