### PR TITLE
Fix UnboundLocalError in realtime_runner

### DIFF
--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -321,7 +321,6 @@ def run_bot_live(settings=None, app=None):
             time.sleep(1)
             continue
         if not getattr(app, "feed_ok", True):
-            import global_state
             print(
                 f"🧪 Letzter Feed-Eingang vor {time.time() - global_state.last_feed_time:.1f} Sekunden"
             )


### PR DESCRIPTION
## Summary
- remove local `global_state` import inside `run_bot_live`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873976e8c68832a9856d9477ccbe23c