### PR TITLE
Refactor candle feed management

### DIFF
--- a/gui/api_credential_frame.py
+++ b/gui/api_credential_frame.py
@@ -129,9 +129,9 @@ class APICredentialFrame(ttk.LabelFrame):
         self.market_status_label.config(foreground=color)
 
     def check_market_feed(self) -> None:
-        from data_provider import websocket_active
+        from data_provider import is_websocket_running
 
-        ok = websocket_active()
+        ok = is_websocket_running()
         self.update_market_status(ok)
 
     # ------------------------------------------------------------------

--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -12,7 +12,7 @@ from api_key_manager import APICredentialManager
 from status_events import StatusDispatcher
 
 class TradingGUI(TradingGUILogicMixin):
-    def __init__(self, root, cred_manager: APICredentialManager | None = None):
+    def __init__(self, root, cred_manager: APICredentialManager | None = None, price_var: tk.StringVar | None = None):
         self.root = root
         # Set window title to reflect the new project name
         self.root.title("🧞‍♂️ EntryMaster_Tradingview – Kapital-Safe Edition")
@@ -24,6 +24,7 @@ class TradingGUI(TradingGUILogicMixin):
         self.running = False
         self.force_exit = False
         self.live_pnl = 0.0
+        self.price_var = price_var or tk.StringVar(value="--")
 
         self.auto_apply_recommendations = tk.BooleanVar(value=False)
         self.auto_multiplier = tk.BooleanVar(value=False)
@@ -233,9 +234,7 @@ class TradingGUI(TradingGUILogicMixin):
         self._on_mode_toggle()
 
         # Preis-Anzeige oben rechts
-        from data_provider import init_price_var, price_var
-        init_price_var(self.root)
-        self.price_label = ttk.Label(top_info, textvariable=price_var, foreground="blue", font=("Arial", 11, "bold"))
+        self.price_label = ttk.Label(top_info, textvariable=self.price_var, foreground="blue", font=("Arial", 11, "bold"))
         self.price_label.pack(side="right", padx=10)
 
         # --- Hauptcontainer ---
@@ -556,10 +555,10 @@ class TradingGUI(TradingGUILogicMixin):
 
         symbol = SETTINGS.get("symbol", "BTCUSDT")
 
-        from data_provider import fetch_last_price, websocket_active
+        from data_provider import fetch_last_price, is_websocket_running
 
         price = fetch_last_price("binance", symbol)
-        self.websocket_active = websocket_active()
+        self.websocket_active = is_websocket_running()
 
         stamp = datetime.now().strftime("%H:%M:%S")
         line = (

--- a/main.py
+++ b/main.py
@@ -22,12 +22,10 @@ from gui_bridge import GUIBridge
 from realtime_runner import run_bot_live
 from global_state import entry_time_global, ema_trend_global, atr_value_global
 from binance_ws import BinanceWebSocket
-import data_provider
 
 # Tk root and shared price variable
 root = tk.Tk()
-data_provider.init_price_var(root)
-price_var = data_provider.price_var
+price_var = tk.StringVar(value="--")
 
 init(autoreset=True)
 setup_logging()
@@ -148,7 +146,7 @@ def main():
     ws = BinanceWebSocket(update_price)
     ws.start()
     cred_manager = APICredentialManager()
-    gui = EntryMasterGUI(root, cred_manager=cred_manager)
+    gui = EntryMasterGUI(root, cred_manager=cred_manager, price_var=price_var)
     gui_bridge = GUIBridge(gui_instance=gui)
     gui.callback = lambda: on_gui_start(gui)
 


### PR DESCRIPTION
## Summary
- remove unused Tk price handling from `data_provider`
- simplify candle websocket startup and monitoring
- expose feed status via `is_websocket_running` only
- adapt GUI components to new API
- keep live price display via parameter in GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873ac55ef38832abaf6eab861bac056