### PR TITLE
Refactor websocket status handling

### DIFF
--- a/data_provider.py
+++ b/data_provider.py
@@ -201,9 +201,6 @@ def monitor_feed(symbol: str, interval: str) -> None:
     )
     _FEED_MONITOR_THREAD.start()
 
-def websocket_active() -> bool:
-    return WebSocketStatus.is_running()
-
 def get_last_candle_time() -> Optional[float]:
     return binance_ws.last_candle_time
 

--- a/gui/api_credential_frame.py
+++ b/gui/api_credential_frame.py
@@ -129,9 +129,9 @@ class APICredentialFrame(ttk.LabelFrame):
         self.market_status_label.config(foreground=color)
 
     def check_market_feed(self) -> None:
-        from data_provider import websocket_active
+        from data_provider import WebSocketStatus
 
-        ok = websocket_active()
+        ok = WebSocketStatus.is_running()
         self.update_market_status(ok)
 
     # ------------------------------------------------------------------

--- a/gui/trading_gui_core.py
+++ b/gui/trading_gui_core.py
@@ -556,10 +556,10 @@ class TradingGUI(TradingGUILogicMixin):
 
         symbol = SETTINGS.get("symbol", "BTCUSDT")
 
-        from data_provider import fetch_last_price, websocket_active
+        from data_provider import fetch_last_price, WebSocketStatus
 
         price = fetch_last_price("binance", symbol)
-        self.websocket_active = websocket_active()
+        self.websocket_active = WebSocketStatus.is_running()
 
         stamp = datetime.now().strftime("%H:%M:%S")
         line = (

--- a/system_monitor.py
+++ b/system_monitor.py
@@ -110,15 +110,10 @@ class SystemMonitor:
         self._feed_ok = False
 
     def _handle_feed_up(self) -> None:
-        if not self._feed_ok:
-            if hasattr(self.gui, "update_feed_status"):
-                self.gui.update_feed_status(True)
-            StatusDispatcher.dispatch("feed", True)
-            if not getattr(self.gui, "running", False) and self._pause_reason == "feed":
-                self.gui.running = True
-            self._pause_reason = None
-        else:
-            if hasattr(self.gui, "update_feed_status"):
-                self.gui.update_feed_status(True)
-            StatusDispatcher.dispatch("feed", True)
+        if not self._feed_ok and not getattr(self.gui, "running", False) and self._pause_reason == "feed":
+            self.gui.running = True
+        self._pause_reason = None
+        if hasattr(self.gui, "update_feed_status"):
+            self.gui.update_feed_status(True)
+        StatusDispatcher.dispatch("feed", True)
         self._feed_ok = True


### PR DESCRIPTION
## Summary
- remove unused `websocket_active` wrapper
- query websocket state via `WebSocketStatus.is_running`
- simplify feed recovery logic in `SystemMonitor`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68740d47f244832a9fd0bc00daed13ff