### PR TITLE
Improve websocket robustness and debug logs

### DIFF
--- a/binance_ws.py
+++ b/binance_ws.py
@@ -132,6 +132,8 @@ class BinanceCandleWebSocket(BaseWebSocket):
                 "volume": float(k.get("v")),
             }
 
+            logger.debug("Candle received: %s", candle)
+
             last_candle_time = time.time()
 
             if self.on_candle:

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -271,7 +271,10 @@ def run_bot_live(settings=None, app=None):
 
     print_start_banner(capital)
 
-    start_candle_websocket(settings["symbol"], settings.get("interval", "1m"))
+    if not data_provider._CANDLE_WS_STARTED:
+        start_candle_websocket(settings["symbol"], settings.get("interval", "1m"))
+    else:
+        logging.info("Candle WebSocket already running")
 
     if app:
         settings["log_event"] = app.log_event


### PR DESCRIPTION
## Summary
- restart websockets cleanly before new connection
- guard candle websocket restarts
- loosen candle validity check and log update calls
- log candle data immediately when received
- avoid double starts in realtime runner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68742a7cfa04832ab7c48d5c88ee7bdb