### PR TITLE
Switch GUI to BitMEX-only API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EntryMaster Trading Bot
 
-**EntryMaster** ist ein professioneller BTC/USDT-Trading-Bot. Die Marktanalyse nutzt ausschließlich **Binance Spot** Live-Marktdaten per **WebSocket**, während alle echten Trades über **BitMEX** ausgeführt werden. Der Bot kombiniert eine leistungsstarke Entry-Strategie (Andac Entry Master) mit adaptivem Risiko-Management, einem benutzerfreundlichen GUI-Interface und einem vollständig simulierbaren Paper-Trading-Modus.
+**EntryMaster** ist ein professioneller BTC/USDT-Trading-Bot. Die Marktanalyse nutzt Candle-Daten der **Binance**-WebSocket, während sämtliche Orders ausschließlich über die **BitMEX REST-API** auf **XBTUSD** ausgeführt werden. Der Bot kombiniert eine leistungsstarke Entry-Strategie (Andac Entry Master) mit adaptivem Risiko-Management, einem benutzerfreundlichen GUI-Interface und einem vollständig simulierbaren Paper-Trading-Modus.
 
 Dieses Repository folgt drei Prinzipien:
 - Alle Dateien liegen direkt im Hauptordner
@@ -11,7 +11,8 @@ Dieses Repository folgt drei Prinzipien:
 
 ## 🚀 Funktionen im Überblick
 
-- 📡 **WebSocket-only Betrieb**: Preis- und Candle-Daten ausschließlich via `wss://stream.binance.com` – kein REST-Zugriff.
+- 📡 **Binance-WebSocket** liefert Kerzen zur Entscheidungsfindung (`wss://stream.binance.com`).
+- 📄 **Orders ausschließlich über BitMEX REST** auf `XBTUSD`.
 - ⏱️ **1-Minuten-Candles** (`kline_1m`) für präzise Entry-/Exit-Entscheidungen.
 - ✅ **Nur abgeschlossene Candles** (`kline['x'] == True`) werden verarbeitet.
 - 📊 **Adaptive SL/TP-Logik**: auf Basis von ATR und Candle-Historie.

--- a/api_credential_frame.py
+++ b/api_credential_frame.py
@@ -6,8 +6,9 @@ from typing import Dict
 from api_key_manager import APICredentialManager
 from status_events import StatusDispatcher
 from config import SETTINGS
+from bitmex_interface import set_credentials, check_credentials
 
-EXCHANGES = ["Binance"]
+EXCHANGES = ["BitMEX"]
 
 class APICredentialFrame(ttk.LabelFrame):
 
@@ -113,11 +114,15 @@ class APICredentialFrame(ttk.LabelFrame):
         if not key or not secret:
             ok, msg = False, "API Key und Secret erforderlich"
         else:
-            ok, msg = True, "API Daten gespeichert"
+            self.cred_manager.set_credentials(key, secret)
+            set_credentials(key, secret)
+            ok = check_credentials()
+            msg = "API Daten gespeichert" if ok else "API Test fehlgeschlagen"
         if ok:
             SETTINGS[f"{exch.lower()}_key"] = key
             SETTINGS[f"{exch.lower()}_secret"] = secret
         else:
+            self.cred_manager.clear()
             SETTINGS.pop(f"{exch.lower()}_key", None)
             SETTINGS.pop(f"{exch.lower()}_secret", None)
         SETTINGS["data_source_mode"] = "websocket"

--- a/bitmex_interface.py
+++ b/bitmex_interface.py
@@ -89,3 +89,29 @@ def get_open_position() -> Optional[dict]:
         logger.error("get_open_position failed: %s", exc)
         return None
 
+
+def set_credentials(key: str, secret: str) -> None:
+    """Set API credentials for subsequent requests."""
+    global API_KEY, API_SECRET
+    API_KEY = key
+    API_SECRET = secret
+
+
+def check_credentials() -> bool:
+    """Verify that the current credentials are valid."""
+    path = "/api/v1/position"
+    params = {"filter": json.dumps({"symbol": SYMBOL}), "count": 1}
+    query = "?" + "&".join(f"{k}={v}" for k, v in params.items())
+    try:
+        headers = _make_headers("GET", path + query)
+    except Exception as exc:
+        logger.error("check_credentials failed: %s", exc)
+        return False
+    url = BASE_URL + path
+    try:
+        resp = requests.get(url, headers=headers, params=params, timeout=5)
+        return resp.status_code == 200
+    except Exception as exc:
+        logger.error("check_credentials failed: %s", exc)
+        return False
+

--- a/trading_gui_core.py
+++ b/trading_gui_core.py
@@ -163,7 +163,7 @@ class TradingGUI(TradingGUILogicMixin):
         self.sl_tp_auto_active = tk.BooleanVar(value=False)
         self.sl_tp_manual_active = tk.BooleanVar(value=False)
 
-        self.api_status_var = tk.StringVar(value="API ❌")
+        self.api_status_var = tk.StringVar(value="BitMEX API ❌")
         self.feed_status_var = tk.StringVar(value="Feed ❌")
         self.api_status_label = None
         self.feed_status_label = None

--- a/trading_gui_logic.py
+++ b/trading_gui_logic.py
@@ -168,24 +168,21 @@ class TradingGUILogicMixin:
             return
         self._last_api_status = (ok, reason)
         self.api_ok = ok
+        stamp = datetime.now().strftime("%H:%M:%S")
         if ok:
-            if hasattr(self, "api_status_label") and self.api_status_label.winfo_ismapped():
-                self.api_status_label.pack_forget()
-            if hasattr(self, "api_status_var"):
-                self.api_status_var.set("")
-            if hasattr(self, "neon_panel"):
-                self.neon_panel.set_status("api", "green", "API OK")
+            text = "BitMEX API ✅"
+            color = "green"
         else:
-            stamp = datetime.now().strftime("%H:%M:%S")
-            text = f"API ❌" + (f" – {reason} ({stamp})" if reason else f" ({stamp})")
-            if hasattr(self, "api_status_var"):
-                self.api_status_var.set(text)
-            if hasattr(self, "api_status_label"):
-                self.api_status_label.config(foreground="red")
-                if not self.api_status_label.winfo_ismapped():
-                    self.api_status_label.pack(side="left", padx=10)
-            if hasattr(self, "neon_panel"):
-                self.neon_panel.set_status("api", "red", text)
+            text = f"BitMEX API ❌" + (f" – {reason} ({stamp})" if reason else f" ({stamp})")
+            color = "red"
+        if hasattr(self, "api_status_var"):
+            self.api_status_var.set(text)
+        if hasattr(self, "api_status_label"):
+            self.api_status_label.config(foreground=color)
+            if not self.api_status_label.winfo_ismapped():
+                self.api_status_label.pack(side="left", padx=10)
+        if hasattr(self, "neon_panel"):
+            self.neon_panel.set_status("api", color, text)
 
     def update_feed_status(self, ok: bool, reason: str | None = None) -> None:
         if getattr(self, "_last_feed_status", (None, None)) == (ok, reason):
@@ -261,7 +258,7 @@ class TradingGUILogicMixin:
     def log_event(self, msg):
         from central_logger import log_messages
 
-        ignore = ["Only Binance spot data supported", "Antwort unvollständig"]
+        ignore = ["Antwort unvollständig"]
         if any(txt in msg for txt in ignore):
             return
 

--- a/tuning_config.json
+++ b/tuning_config.json
@@ -36,7 +36,7 @@
   "manual_tp_var": "",
   "sl_tp_auto_active": false,
   "sl_tp_manual_active": false,
-  "api_status_var": "API \u274c",
+  "api_status_var": "BitMEX API \u274c",
   "feed_status_var": "",
   "feed_ok": true,
   "api_ok": false,


### PR DESCRIPTION
## Summary
- update docs to clarify Binance is only used for candle feed
- remove Binance from API credential UI and expect BitMEX keys
- check BitMEX credentials via REST and display result
- expose helpers in `bitmex_interface` for setting and checking credentials
- show `BitMEX API` status in GUI
- update stored config with new default text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687445677ebc832a9e5d394829dabb02