### PR TITLE
Refine feed status and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **EntryMaster** ist ein professioneller BTC/USDT-Trading-Bot. Die Marktanalyse nutzt Candle-Daten der **Binance**-WebSocket, während sämtliche Orders ausschließlich über die **BitMEX REST-API** auf **XBTUSD** ausgeführt werden. Der Bot kombiniert eine leistungsstarke Entry-Strategie (Andac Entry Master) mit adaptivem Risiko-Management, einem benutzerfreundlichen GUI-Interface und einem vollständig simulierbaren Paper-Trading-Modus.
 
+👉 **Nur eine Datenquelle:** Es gibt keinerlei REST-Fallback oder zweite WebSocket. Alle Marktdaten stammen ausschließlich von der Binance WebSocket, während BitMEX als einziger Broker genutzt wird.
+
 Dieses Repository folgt drei Prinzipien:
 - Alle Dateien liegen direkt im Hauptordner
 - Jede Datei startet mit `# dateiname.py`
@@ -13,6 +15,7 @@ Dieses Repository folgt drei Prinzipien:
 
 - 📡 **Binance-WebSocket** liefert Kerzen zur Entscheidungsfindung (`wss://stream.binance.com`).
 - 📄 **Orders ausschließlich über BitMEX REST** auf `XBTUSD`.
+- ❌ Kein REST-Fallback oder zweite Datenquelle – Minimalismus pur.
 - ⏱️ **1-Minuten-Candles** (`kline_1m`) für präzise Entry-/Exit-Entscheidungen.
 - ✅ **Nur abgeschlossene Candles** (`kline['x'] == True`) werden verarbeitet.
 - 📊 **Adaptive SL/TP-Logik**: auf Basis von ATR und Candle-Historie.
@@ -122,7 +125,7 @@ python main.py
 ## ✅ Beispiel-Statusanzeige
 
 ```text
-✅ Marktdaten kommen an | ✅ SL aktiv | ✅ TP aktiv | 🟢 WebSocket verbunden
+✅ Marktdaten kommen an | ✅ SL aktiv | ✅ TP aktiv | 🟢 Binance WebSocket OK
 ```
 
 ---

--- a/binance_ws.py
+++ b/binance_ws.py
@@ -74,6 +74,7 @@ class BinanceCandleWebSocket(BaseWebSocket):
             try:
                 self.ws = WebSocketApp(
                     self.url,
+                    on_open=self._on_open,
                     on_message=self._on_message,
                     on_error=self._on_error,
                     on_close=self._on_close,
@@ -136,3 +137,6 @@ class BinanceCandleWebSocket(BaseWebSocket):
 
     def _on_close(self, ws, status_code, msg):
         logger.info("Candle-WS geschlossen: %s %s", status_code, msg)
+
+    def _on_open(self, ws):
+        logger.info("Binance WebSocket verbunden")

--- a/trading_gui_logic.py
+++ b/trading_gui_logic.py
@@ -196,12 +196,12 @@ class TradingGUILogicMixin:
             if hasattr(self, "feed_status_var"):
                 self.feed_status_var.set("")
             if hasattr(self, "neon_panel"):
-                self.neon_panel.set_status("feed", "green", "Feed OK")
+                self.neon_panel.set_status("feed", "green", "Binance WebSocket OK")
             if hasattr(self, "api_frame") and hasattr(self.api_frame, "update_market_status"):
                 self.api_frame.update_market_status(True)
         else:
             stamp = datetime.now().strftime("%H:%M:%S")
-            text = f"Feed ❌" + (f" – {reason} ({stamp})" if reason else f" ({stamp})")
+            text = f"Binance WebSocket ❌" + (f" – {reason} ({stamp})" if reason else f" ({stamp})")
             if hasattr(self, "feed_status_var"):
                 self.feed_status_var.set(text)
             if hasattr(self, "feed_status_label"):
@@ -215,10 +215,10 @@ class TradingGUILogicMixin:
 
     def _update_feed_mode_display(self, ok: bool) -> None:
         if not ok:
-            text = "❌ WebSocket getrennt"
+            text = "Binance WebSocket ❌"
             color = "red"
         else:
-            text = "WebSocket verbunden"
+            text = "Binance WebSocket OK"
             color = "green"
 
         if hasattr(self, "feed_mode_var"):

--- a/tuning_config.json
+++ b/tuning_config.json
@@ -42,7 +42,7 @@
   "api_ok": false,
   "websocket_active": true,
   "system_status_var": "\u2705 Alle Systeme laufen fehlerfrei",
-  "feed_mode_var": "WebSocket verbunden",
+  "feed_mode_var": "Binance WebSocket OK",
   "market_interval_ms": 1000,
   "time_filters": [
     [


### PR DESCRIPTION
## Summary
- mark single Binance WebSocket client on connect
- show Binance WebSocket feed state in GUI
- document unique Binance WebSocket feed and BitMEX execution
- update config defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687448b240d0832a8da186308159f6cf