### PR TITLE
Refactor GUI state and add offline tools

### DIFF
--- a/entry_logic.py
+++ b/entry_logic.py
@@ -1,0 +1,11 @@
+# entry_logic.py
+"""Simple wrapper around the entry indicator."""
+
+from __future__ import annotations
+
+from andac_entry_master import AndacEntryMaster, AndacSignal
+
+
+def should_enter(candle: dict, indicator: AndacEntryMaster) -> AndacSignal:
+    """Return the indicator evaluation for a given candle."""
+    return indicator.evaluate(candle)

--- a/feed_simulator.py
+++ b/feed_simulator.py
@@ -1,0 +1,41 @@
+# feed_simulator.py
+"""Offline candle feed for strategy testing."""
+
+from __future__ import annotations
+
+import csv
+import json
+import time
+from typing import Callable, Iterable, Iterator, Dict
+
+
+class FeedSimulator:
+    """Load candles from file and feed them sequentially."""
+
+    def __init__(self, filename: str) -> None:
+        self.filename = filename
+
+    def _read_json(self) -> Iterator[Dict[str, float]]:
+        with open(self.filename, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    yield json.loads(line)
+
+    def _read_csv(self) -> Iterator[Dict[str, float]]:
+        with open(self.filename, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                row = {k: float(v) if k != "timestamp" else int(v) for k, v in row.items()}
+                yield row
+
+    def candles(self) -> Iterable[Dict[str, float]]:
+        if self.filename.lower().endswith(".json"):
+            return self._read_json()
+        return self._read_csv()
+
+    def run(self, callback: Callable[[Dict[str, float]], None], delay: float = 0.0) -> None:
+        """Send each candle to *callback* with optional delay in seconds."""
+        for candle in self.candles():
+            callback(candle)
+            if delay > 0:
+                time.sleep(delay)

--- a/gui_model.py
+++ b/gui_model.py
@@ -1,0 +1,105 @@
+# gui_model.py
+"""Model holding GUI state variables and basic control helpers."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from typing import Optional
+
+
+class GUIModel:
+    """Container for Tkinter variables and runtime state."""
+
+    def __init__(self, root: tk.Misc) -> None:
+        # runtime flags
+        self.running: bool = False
+        self.force_exit: bool = False
+        self.live_pnl: float = 0.0
+
+        # general options
+        self.auto_apply_recommendations = tk.BooleanVar(master=root, value=False)
+        self.auto_multiplier = tk.BooleanVar(master=root, value=False)
+
+        # Auto Partial Close
+        self.apc_enabled = tk.BooleanVar(master=root, value=False)
+        self.apc_rate = tk.StringVar(master=root, value="10")
+        self.apc_interval = tk.StringVar(master=root, value="60")
+        self.apc_min_profit = tk.StringVar(master=root, value="0")
+
+        # risk limits
+        self.max_loss_enabled = tk.BooleanVar(master=root, value=True)
+        self.max_loss_value = tk.StringVar(master=root, value="10")
+
+        # trading mode
+        self.live_trading = tk.BooleanVar(master=root, value=False)
+        self.paper_mode = tk.BooleanVar(master=root, value=True)
+        self.trading_mode = tk.StringVar(master=root, value="paper")
+
+        # basic parameters
+        self.multiplier_var = tk.StringVar(master=root, value="20")
+        self.capital_var = tk.StringVar(master=root, value="1000")
+
+        # strategy options
+        self.andac_lookback = tk.StringVar(master=root, value="20")
+        self.andac_puffer = tk.StringVar(master=root, value="10.0")
+        self.andac_vol_mult = tk.StringVar(master=root, value="1.2")
+
+        self.andac_opt_rsi_ema = tk.BooleanVar(master=root)
+        self.andac_opt_safe_mode = tk.BooleanVar(master=root)
+        self.andac_opt_engulf = tk.BooleanVar(master=root)
+        self.andac_opt_engulf_bruch = tk.BooleanVar(master=root)
+        self.andac_opt_engulf_big = tk.BooleanVar(master=root)
+        self.andac_opt_confirm_delay = tk.BooleanVar(master=root)
+        self.andac_opt_mtf_confirm = tk.BooleanVar(master=root)
+        self.andac_opt_volumen_strong = tk.BooleanVar(master=root)
+        self.andac_opt_session_filter = tk.BooleanVar(master=root)
+
+        self.use_doji_blocker = tk.BooleanVar(master=root)
+
+        # timing
+        self.interval = tk.StringVar(master=root, value="1m")
+        self.use_time_filter = tk.BooleanVar(master=root)
+        self.time_start = tk.StringVar(master=root, value="08:00")
+        self.time_end = tk.StringVar(master=root, value="18:00")
+
+        # manual SL/TP
+        self.manual_sl_var = tk.StringVar(master=root, value="")
+        self.manual_tp_var = tk.StringVar(master=root, value="")
+        self.sl_tp_auto_active = tk.BooleanVar(master=root, value=False)
+        self.sl_tp_manual_active = tk.BooleanVar(master=root, value=False)
+
+        # connection status
+        self.feed_ok: bool = False
+        self.api_ok: bool = False
+        self.websocket_active: bool = False
+
+    # --- helper methods -------------------------------------------------
+    def toggle_manual_sl_tp(self, sl: Optional[str], tp: Optional[str]) -> bool:
+        """Enable manual SL/TP if both values are valid."""
+        try:
+            float(sl.replace(",", "."))
+            float(tp.replace(",", "."))
+        except Exception:
+            self.sl_tp_manual_active.set(False)
+            return False
+
+        self.manual_sl_var.set(sl)
+        self.manual_tp_var.set(tp)
+        self.sl_tp_manual_active.set(True)
+        self.sl_tp_auto_active.set(False)
+        return True
+
+    def activate_auto_sl_tp(self) -> None:
+        """Switch SL/TP handling to automatic mode."""
+        self.sl_tp_auto_active.set(True)
+        self.sl_tp_manual_active.set(False)
+
+    def set_auto_sl_status(self, ok: bool) -> None:
+        self.sl_tp_auto_active.set(ok)
+        if ok:
+            self.sl_tp_manual_active.set(False)
+
+    def set_manual_sl_status(self, ok: bool) -> None:
+        self.sl_tp_manual_active.set(ok)
+        if ok:
+            self.sl_tp_auto_active.set(False)

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -38,6 +38,7 @@ import global_state
 from indicator_utils import calculate_ema, calculate_atr
 
 from andac_entry_master import AndacEntryMaster, AndacSignal
+from entry_logic import should_enter
 from adaptive_sl_manager import AdaptiveSLManager
 
 
@@ -277,6 +278,12 @@ def run_bot_live(settings=None, app=None):
         start_capital = capital
 
     risk_manager = RiskManager(app, start_capital)
+    cfg = {}
+    for key in ("max_loss", "max_drawdown", "max_trades"):
+        if key in settings:
+            cfg[key] = settings[key]
+    if cfg:
+        risk_manager.configure(**cfg)
 
     multiplier = gui_bridge.multiplier
     capital = float(gui_bridge.capital)
@@ -408,7 +415,7 @@ def run_bot_live(settings=None, app=None):
             except Exception as e:
                 print(f"⚠️ Automatisches Anwenden fehlgeschlagen: {e}")
 
-        andac_signal: AndacSignal = andac_indicator.evaluate(candle)
+        andac_signal: AndacSignal = should_enter(candle, andac_indicator)
         entry_type = andac_signal.signal
         stamp = datetime.now().strftime("%H:%M:%S")
         if entry_type:

--- a/trading_gui_logic.py
+++ b/trading_gui_logic.py
@@ -134,7 +134,10 @@ class TradingGUILogicMixin:
 
     def emergency_exit(self):
         try:
-            self.running = False
+            if hasattr(self, "model"):
+                self.model.running = False
+            else:
+                self.running = False
             if hasattr(self, "close_all_positions"):
                 self.close_all_positions()
             self.log_event("❗️ Notausstieg ausgelöst! Alle Positionen werden geschlossen.")
@@ -142,8 +145,12 @@ class TradingGUILogicMixin:
             print(f"❌ Fehler beim Notausstieg: {e}")
 
     def emergency_flat_position(self):
-        self.force_exit = True
-        self.running = False
+        if hasattr(self, "model"):
+            self.model.force_exit = True
+            self.model.running = False
+        else:
+            self.force_exit = True
+            self.running = False
         self.log_event("⛔ Trade abbrechen: Die Position wird jetzt geschlossen.")
         
         if hasattr(self, 'position') and self.position is not None:
@@ -153,8 +160,12 @@ class TradingGUILogicMixin:
             self.log_event("❌ Keine offene Position zum Abbrechen gefunden.")
 
     def abort_trade(self):
-        self.force_exit = True
-        self.running = False
+        if hasattr(self, "model"):
+            self.model.force_exit = True
+            self.model.running = False
+        else:
+            self.force_exit = True
+            self.running = False
 
     def update_live_trade_pnl(self, pnl):
         color = "green" if pnl >= 0 else "red"
@@ -167,7 +178,10 @@ class TradingGUILogicMixin:
         if getattr(self, "_last_api_status", (None, None)) == (ok, reason):
             return
         self._last_api_status = (ok, reason)
-        self.api_ok = ok
+        if hasattr(self, "model"):
+            self.model.api_ok = ok
+        else:
+            self.api_ok = ok
         stamp = datetime.now().strftime("%H:%M:%S")
         if ok:
             text = "BitMEX API ✅"
@@ -188,7 +202,10 @@ class TradingGUILogicMixin:
         if getattr(self, "_last_feed_status", (None, None)) == (ok, reason):
             return
         self._last_feed_status = (ok, reason)
-        self.feed_ok = ok
+        if hasattr(self, "model"):
+            self.model.feed_ok = ok
+        else:
+            self.feed_ok = ok
         self._update_feed_mode_display(ok)
         if ok:
             if hasattr(self, "feed_status_label") and self.feed_status_label.winfo_ismapped():
@@ -340,18 +357,16 @@ class TradingGUILogicMixin:
             return var.get()
 
     def toggle_manual_sl_tp(self):
-        try:
-            sl = float(self.manual_sl_var.get().replace(",", "."))
-            tp = float(self.manual_tp_var.get().replace(",", "."))
-        except Exception:
-            self.sl_tp_manual_active.set(False)
+        ok = False
+        if hasattr(self, "model"):
+            sl = self.manual_sl_var.get()
+            tp = self.manual_tp_var.get()
+            ok = self.model.toggle_manual_sl_tp(sl, tp)
+        if not ok:
             if hasattr(self, "manual_sl_button"):
                 self.manual_sl_button.config(fg="red")
             self.log_event("❌ Ungültige manuelle SL/TP Werte")
             return
-
-        self.sl_tp_manual_active.set(True)
-        self.sl_tp_auto_active.set(False)
         if hasattr(self, "manual_sl_button"):
             self.manual_sl_button.config(fg="blue")
         if hasattr(self, "auto_sl_button"):
@@ -359,8 +374,11 @@ class TradingGUILogicMixin:
         self.log_event("📝 Manuelle SL/TP aktiviert")
 
     def activate_auto_sl_tp(self):
-        self.sl_tp_auto_active.set(True)
-        self.sl_tp_manual_active.set(False)
+        if hasattr(self, "model"):
+            self.model.activate_auto_sl_tp()
+        else:
+            self.sl_tp_auto_active.set(True)
+            self.sl_tp_manual_active.set(False)
         if hasattr(self, "auto_sl_button"):
             self.auto_sl_button.config(fg="blue")
         if hasattr(self, "manual_sl_button"):
@@ -368,24 +386,34 @@ class TradingGUILogicMixin:
         self.log_event("⚙️ Adaptive SL/TP aktiviert")
 
     def set_auto_sl_status(self, ok: bool) -> None:
-        self.sl_tp_auto_active.set(ok)
-        if ok:
-            self.sl_tp_manual_active.set(False)
+        if hasattr(self, "model"):
+            self.model.set_auto_sl_status(ok)
+        else:
+            self.sl_tp_auto_active.set(ok)
+            if ok:
+                self.sl_tp_manual_active.set(False)
         if hasattr(self, "auto_sl_button"):
             color = "green" if ok else "red"
             self.auto_sl_button.config(fg=color)
 
     def set_manual_sl_status(self, ok: bool) -> None:
-        self.sl_tp_manual_active.set(ok)
-        if ok:
-            self.sl_tp_auto_active.set(False)
+        if hasattr(self, "model"):
+            self.model.set_manual_sl_status(ok)
+        else:
+            self.sl_tp_manual_active.set(ok)
+            if ok:
+                self.sl_tp_auto_active.set(False)
         if hasattr(self, "manual_sl_button"):
             color = "green" if ok else "red"
             self.manual_sl_button.config(fg=color)
 
 def stop_and_reset(self):
-    self.force_exit = True
-    self.running = False
+    if hasattr(self, "model"):
+        self.model.force_exit = True
+        self.model.running = False
+    else:
+        self.force_exit = True
+        self.running = False
     try:
         self.log_event("🧹 Bot gestoppt – Keine Rücksetzung der Konfiguration vorgenommen.")
     except Exception as e:


### PR DESCRIPTION
## Summary
- introduce `GUIModel` for GUI state management
- delegate manual SL/TP logic to the model
- provide `FeedSimulator` and `should_enter` helper
- allow runtime risk configuration via `RiskManager.configure`
- update realtime runner and GUI to use the new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6874a5e15028832aa5ec64913df35758