### PR TITLE
Add REST backfill and dynamic timeframe

### DIFF
--- a/binance_ws.py
+++ b/binance_ws.py
@@ -63,10 +63,11 @@ class BinanceCandleWebSocket(BaseWebSocket):
     def __init__(
         self,
         on_candle: Optional[Callable[[dict], None]] = None,
+        interval: str | None = None,
     ):
         self.on_candle = on_candle
         self.symbol = BINANCE_SYMBOL.lower()
-        self.interval = BINANCE_INTERVAL
+        self.interval = interval or BINANCE_INTERVAL
         url = f"wss://stream.binance.com:9443/ws/{self.symbol}@kline_{self.interval}"
         super().__init__(url, self._on_message)
         self._warning_printed = False

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -269,8 +269,9 @@ def _run_bot_live_inner(settings=None, app=None):
 
     print_start_banner(capital)
 
+    interval_setting = settings.get("interval", BINANCE_INTERVAL)
     if not data_provider._CANDLE_WS_STARTED:
-        start_candle_websocket()
+        start_candle_websocket(interval_setting)
     else:
         logging.info("Candle WebSocket already running")
 
@@ -292,7 +293,7 @@ def _run_bot_live_inner(settings=None, app=None):
     multiplier = gui_bridge.multiplier
     capital = float(gui_bridge.capital)
     start_capital = capital
-    interval = BINANCE_INTERVAL
+    interval = interval_setting
     auto_multi = gui_bridge.auto_multiplier
 
     ATR_REQUIRED = 14

--- a/trading_gui_logic.py
+++ b/trading_gui_logic.py
@@ -214,15 +214,21 @@ class TradingGUILogicMixin:
             self.model.feed_ok = ok
         else:
             self.feed_ok = ok
-        self._update_feed_mode_display(ok)
-        color = "green" if ok else "red"
-        text = "✅ Feed stabil" if ok else "❌ Kein Feed"
-        if not ok and reason:
-            if "Reconnect" in reason:
-                color = "orange"
-                text = f"🔄 {reason}"
-            else:
-                text = f"❌ {reason}"
+        if reason == "REST-API-Call-14":
+            color = "orange"
+            text = reason
+            if hasattr(self, "feed_mode_var"):
+                self.feed_mode_var.set(reason)
+        else:
+            self._update_feed_mode_display(ok)
+            color = "green" if ok else "red"
+            text = "✅ Feed stabil" if ok else "❌ Kein Feed"
+            if not ok and reason:
+                if "Reconnect" in reason:
+                    color = "orange"
+                    text = f"🔄 {reason}"
+                else:
+                    text = f"❌ {reason}"
 
         if hasattr(self, "feed_status_var"):
             self.feed_status_var.set(text if not ok else "")


### PR DESCRIPTION
## Summary
- fetch initial candles from Binance REST API before WebSocket startup
- allow WebSocket interval to be specified dynamically
- propagate chosen interval through realtime runner
- show `REST-API-Call-14` status while loading candles

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6874c3e451c8832ab3b5edf2b8424071