### PR TITLE
Fix startup queue issues and None checks

### DIFF
--- a/main.py
+++ b/main.py
@@ -122,7 +122,7 @@ def bot_control(gui):
                 status = (
                     f"{farbe} Aktueller PnL: ${pnl:.1f} | Laufzeit: {laufzeit}s | ⏰ {uhrzeit} | 📅 {datum}\n"
                     f"💼 Kapital: ${capital:.2f} | 📊 Lev: x{leverage} | 📍 Trade: {trade_info}\n"
-                    f"📉 ATR: ${atr_value_global:.1f} | 📈 EMA: {ema_trend_global} | 🚀 Modus: {'LIVE' if gui.live_trading.get() else 'SIMULATION'}\n"
+                    f"📉 ATR: ${atr_value_global if atr_value_global is not None else 0.0:.1f} | 📈 EMA: {ema_trend_global} | 🚀 Modus: {'LIVE' if gui.live_trading.get() else 'SIMULATION'}\n"
                     f"{filter_line}"
                 )
                 print(status + Style.RESET_ALL)

--- a/signal_worker.py
+++ b/signal_worker.py
@@ -12,9 +12,14 @@ from status_events import StatusDispatcher
 class SignalWorker:
     """Process candle data on a separate thread."""
 
-    def __init__(self, handler: Callable[[dict], Any], maxsize: int = 100) -> None:
+    def __init__(
+        self,
+        handler: Callable[[dict], Any],
+        queue_obj: queue.Queue | None = None,
+        maxsize: int = 100,
+    ) -> None:
         self.handler = handler
-        self.queue: queue.Queue[dict] = queue.Queue(maxsize=maxsize)
+        self.queue: queue.Queue[dict] = queue_obj or queue.Queue(maxsize=maxsize)
         self._running = False
         self.thread: threading.Thread | None = None
         self.logger = logging.getLogger(__name__)

--- a/trading_gui_logic.py
+++ b/trading_gui_logic.py
@@ -16,6 +16,9 @@ class TradingGUILogicMixin:
             from config import SETTINGS
 
             volatility = atr_value_global
+            if volatility is None:
+                self.log_event("⚠️ ATR noch nicht verfügbar - Empfehlungen übersprungen")
+                return
             # REMOVED: SessionFilter
             hour = datetime.utcnow().hour
             if 6 <= hour < 14:


### PR DESCRIPTION
## Summary
- avoid ATR-based recommendations when ATR isn't ready
- gracefully handle missing ATR in CLI status output
- allow `SignalWorker` to use an external queue
- process websocket queue directly in `realtime_runner`
- guard SL/TP logic when values are missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6874d23ab480832ab9d877982c74957b