### PR TITLE
Fix UnicodeEncodeError in logger

### DIFF
--- a/central_logger.py
+++ b/central_logger.py
@@ -1,6 +1,7 @@
 # central_logger.py
 import logging
 import sys
+import io
 from logging.handlers import RotatingFileHandler
 import time
 from typing import List
@@ -13,13 +14,17 @@ class SafeStreamHandler(logging.StreamHandler):
             super().emit(record)
         except UnicodeEncodeError:
             msg = self.format(record)
-            fallback = msg.encode("ascii", "replace").decode("ascii") + " [ASCII-Fallback]"
+            fallback = msg.encode("utf-8", "replace").decode("utf-8")
             stream = self.stream
             stream.write(fallback + self.terminator)
             self.flush()
 
 
 def setup_logging(level: int = logging.INFO, logfile: str = "bot.log") -> None:
+    try:
+        sys.stdout = io.TextIOWrapper(sys.stdout.detach(), encoding="utf-8", errors="replace")
+    except Exception:
+        pass
     logging.basicConfig(
         level=level,
         format="%(asctime)s %(levelname)s %(message)s",

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -516,7 +516,7 @@ def _run_bot_live_inner(settings=None, app=None):
     preload = candle_queue.qsize()
     if preload:
         flush_limit = min(preload, 2)
-        logging.info("\ud83d\udd04 Clean Flush %s Candles", flush_limit)
+        logging.info("\U0001F504 Clean Flush %s Candles", flush_limit)
         for _ in range(flush_limit):
             try:
                 process_candle(candle_queue.get_nowait())


### PR DESCRIPTION
## Summary
- ensure central logger gracefully handles Unicode
- enforce UTF-8 stdout with replacement
- use correct emoji code point in realtime runner

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6874e542e244832a8237349a65ac9d95