### PR TITLE
Add triangle signal logging

### DIFF
--- a/central_logger.py
+++ b/central_logger.py
@@ -63,3 +63,18 @@ def log_messages(msg: str, level: int = logging.INFO) -> List[str]:
     for line in out:
         logging.log(level, line)
     return out
+
+
+def log_triangle_signal(signal_type: str, price: float) -> str:
+    """Log a colored triangle signal with timestamp and price."""
+    from datetime import datetime
+
+    stamp = datetime.now().strftime("%H:%M:%S")
+    if signal_type == "long":
+        msg = f"{stamp} \U0001F7E9 Dreieck (LONG) erkannt @ {price:.2f}"
+    elif signal_type == "short":
+        msg = f"{stamp} \U0001F7E5 Dreieck (SHORT) erkannt @ {price:.2f}"
+    else:
+        msg = f"{stamp} \u26AA\uFE0F Unbekanntes Signal"
+    logging.info(msg)
+    return msg

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -31,6 +31,7 @@ from gui_bridge import GUIBridge
 from trading_gui_core import TradingGUI
 from trading_gui_logic import TradingGUILogicMixin
 from config import SETTINGS
+from central_logger import log_triangle_signal
 from global_state import (
     entry_time_global,
     ema_trend_global,
@@ -395,6 +396,9 @@ def _run_bot_live_inner(settings=None, app=None):
         entry_type = andac_signal.signal
         stamp = datetime.now().strftime("%H:%M:%S")
         if entry_type:
+            triangle_msg = log_triangle_signal(entry_type, close_price)
+            if hasattr(app, "log_event"):
+                app.log_event(triangle_msg)
             msg = f"[{stamp}] Signal erkannt: {entry_type.upper()} ({BINANCE_SYMBOL} @ {close_price:.2f})"
             logging.info(msg)
             if hasattr(app, "log_event"):


### PR DESCRIPTION
## Summary
- implement `log_triangle_signal` to log TradeView-style triangle markers
- show visual signal messages in `realtime_runner`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6874e857a7d4832a99d787b5c0fd862d