### PR TITLE
Update signal logic and clean GUI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ Der Bot verwendet eine fortgeschrittene Entry-Strategie:
 - ✅ **Trendfilter** (EMA)
 - ✅ **Volumenstärke-Erkennung**
 - ✅ **Makrophasen-Filter**
-- ✅ **Session-Filter**
-- ⚙️ **Session-Filter konfigurierbar über die GUI**
 - ✅ **Engulfing-Pattern**
 - ✅ **Multi-Timeframe-Bestätigung**
 - 🟢 Alle Signale werden geloggt, mit Gründen bei Verwerfung.
@@ -188,7 +186,6 @@ EntryMaster_Tradingview/
 
 - GUI-basierte Backtests
 - Weitere Assets (nur BTCUSDT bisher)
-- Session-Wizard zur Konfiguration
 - Optimierte Logging-Ausgabe & Reports
 
 ---

--- a/entry_logic.py
+++ b/entry_logic.py
@@ -79,10 +79,11 @@ def should_enter(candle, indicator, config) -> AndacSignal:
         short_final = short_valid
 
     # === Signal zurückgeben
+    engulf = bull_engulfing if long_final else baer_engulfing if short_final else False
     if long_final:
-        return AndacSignal(signal="long")
+        return AndacSignal(signal="long", rsi=rsi, vol_spike=vol_spike, engulfing=engulf)
     elif short_final:
-        return AndacSignal(signal="short")
+        return AndacSignal(signal="short", rsi=rsi, vol_spike=vol_spike, engulfing=engulf)
     else:
-        return AndacSignal(signal=None, reasons=["No signal conditions met"])
+        return AndacSignal(signal=None, rsi=rsi, vol_spike=vol_spike, engulfing=engulf, reasons=["No signal conditions met"])
 

--- a/gui_model.py
+++ b/gui_model.py
@@ -52,8 +52,6 @@ class GUIModel:
         self.andac_opt_confirm_delay = tk.BooleanVar(master=root)
         self.andac_opt_mtf_confirm = tk.BooleanVar(master=root)
         self.andac_opt_volumen_strong = tk.BooleanVar(master=root)
-        self.andac_opt_session_filter = tk.BooleanVar(master=root)
-
         # REMOVED: SessionFilter variables
 
         self.use_doji_blocker = tk.BooleanVar(master=root)

--- a/main.py
+++ b/main.py
@@ -114,7 +114,6 @@ def bot_control(gui):
                     "DELAY": gui.andac_opt_confirm_delay.get(),
                     "MTF": gui.andac_opt_mtf_confirm.get(),
                     "VOL": gui.andac_opt_volumen_strong.get(),
-                    "SES": gui.andac_opt_session_filter.get(),
                 }
                 filter_line = "🎛 Andac: " + " ".join(
                     f"{k}{'✅' if v else '❌'}" for k, v in filter_status.items()

--- a/status_block.py
+++ b/status_block.py
@@ -36,7 +36,6 @@ def get_entry_status_text(position: dict, capital, app, leverage: int, settings:
         "DELAY": app.andac_opt_confirm_delay.get(),
         "MTF": app.andac_opt_mtf_confirm.get(),
         "VOL": app.andac_opt_volumen_strong.get(),
-        "SES": app.andac_opt_session_filter.get(),
     }
     filter_line = "🎛 Andac: " + "  ".join(f"{k}{'✅' if v else '❌'}" for k, v in filters.items())
 

--- a/test_entry_logic.py
+++ b/test_entry_logic.py
@@ -1,15 +1,35 @@
 import unittest
-from andac_entry_master import AndacEntryMaster
 from entry_logic import should_enter
 
 class EntryLogicTest(unittest.TestCase):
     def test_entry_signal_rsi_engulfing(self):
-        indicator = AndacEntryMaster(lookback=1, puffer=1, opt_engulf=True)
-        # history candles
-        indicator.evaluate({"open":100, "high":110, "low":90, "close":95, "volume":1000})
-        indicator.evaluate({"open":108, "high":109, "low":101, "close":102, "volume":1200})
+        indicator = {
+            "rsi": 55,
+            "atr": 2,
+            "avg_volume": 1100,
+            "high_lookback": 110,
+            "low_lookback": 90,
+            "prev_close": 102,
+            "prev_open": 108,
+            "mtf_ok": True,
+            "prev_bull_signal": False,
+            "prev_baer_signal": False,
+        }
+        config = {
+            "lookback": 1,
+            "puffer": 1,
+            "volumen_factor": 1.2,
+            "opt_engulf": True,
+            "opt_engulf_bruch": False,
+            "opt_engulf_big": False,
+            "opt_confirm_delay": False,
+            "opt_mtf_confirm": False,
+            "opt_volumen_strong": False,
+            "opt_safe_mode": False,
+            "opt_rsi_ema": False,
+        }
         candle = {"open":100, "high":112, "low":98, "close":110, "volume":9000}
-        signal = should_enter(candle, indicator)
+        signal = should_enter(candle, indicator, config)
         self.assertEqual(signal.signal, "long")
 
 if __name__ == '__main__':

--- a/trading_gui_core.py
+++ b/trading_gui_core.py
@@ -83,7 +83,6 @@ class TradingGUI(TradingGUILogicMixin):
             "auto_multi": ("Auto Multiplikator", self.auto_multiplier),
             "safe": ("Sicherheitsfilter", self.andac_opt_safe_mode),
             "vol": ("Volumenfilter", self.andac_opt_volumen_strong),
-            "session": ("Session Filter", self.andac_opt_session_filter),
             "paper": ("Paper-Trading aktiv", self.paper_mode),
             "saved": ("Konfiguration gespeichert", None),
         }
@@ -133,7 +132,6 @@ class TradingGUI(TradingGUILogicMixin):
         self.andac_opt_confirm_delay = self.model.andac_opt_confirm_delay
         self.andac_opt_mtf_confirm = self.model.andac_opt_mtf_confirm
         self.andac_opt_volumen_strong = self.model.andac_opt_volumen_strong
-        self.andac_opt_session_filter = self.model.andac_opt_session_filter
 
         # REMOVED: SessionFilter variables
 
@@ -341,7 +339,6 @@ class TradingGUI(TradingGUILogicMixin):
             ("Bestätigungskerze", self.andac_opt_confirm_delay),
             ("MTF Bestätigung", self.andac_opt_mtf_confirm),
             ("Starkes Volumen", self.andac_opt_volumen_strong),
-            ("EU/NY Session", self.andac_opt_session_filter),
         ]:
             ttk.Checkbutton(left_col, text=text, variable=var).pack(anchor="w")
 

--- a/trading_gui_logic.py
+++ b/trading_gui_logic.py
@@ -42,7 +42,6 @@ class TradingGUILogicMixin:
                 self.andac_opt_confirm_delay,
                 self.andac_opt_mtf_confirm,
                 self.andac_opt_volumen_strong,
-                self.andac_opt_session_filter,
                 self.use_doji_blocker,
                 self.use_time_filter,
             ]
@@ -54,7 +53,6 @@ class TradingGUILogicMixin:
             if spike:
                 enable += [
                     self.andac_opt_safe_mode,
-                    self.andac_opt_session_filter,
                     self.use_doji_blocker,
                     self.andac_opt_volumen_strong,
                 ]
@@ -94,7 +92,6 @@ class TradingGUILogicMixin:
                 "opt_confirm_delay": self.andac_opt_confirm_delay.get(),
                 "opt_mtf_confirm": self.andac_opt_mtf_confirm.get(),
                 "opt_volumen_strong": self.andac_opt_volumen_strong.get(),
-                "opt_session_filter": self.andac_opt_session_filter.get(),
             })
 
             self.log_event("✅ Auto-Empfehlungen angewendet")
@@ -112,7 +109,6 @@ class TradingGUILogicMixin:
                 self.andac_opt_confirm_delay,
                 self.andac_opt_mtf_confirm,
                 self.andac_opt_volumen_strong,
-                self.andac_opt_session_filter,
                 self.use_time_filter,
                 self.use_doji_blocker,
             ]:

--- a/tuning_config.json
+++ b/tuning_config.json
@@ -26,7 +26,6 @@
   "andac_opt_confirm_delay": false,
   "andac_opt_mtf_confirm": false,
   "andac_opt_volumen_strong": false,
-  "andac_opt_session_filter": false,
   "use_doji_blocker": false,
   "interval": "1m",
   "use_time_filter": false,


### PR DESCRIPTION
## Summary
- generate indicator dictionary in realtime runner
- call `should_enter` with config dict
- return detailed `AndacSignal` from `entry_logic.py`
- remove session filter option from GUI and status
- adjust tests for new logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6874ee3a8e50832a867d25704201d58b