### PR TITLE
Improve trade simulation with fees and GUI stats

### DIFF
--- a/gui_model.py
+++ b/gui_model.py
@@ -15,6 +15,9 @@ class GUIModel:
         self.running: bool = False
         self.force_exit: bool = False
         self.live_pnl: float = 0.0
+        self.total_pnl: float = 0.0
+        self.wins: int = 0
+        self.losses: int = 0
 
         # general options
         self.auto_apply_recommendations = tk.BooleanVar(master=root, value=False)

--- a/simulator.py
+++ b/simulator.py
@@ -1,0 +1,29 @@
+# simulator.py
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+from pnl_utils import calculate_futures_pnl
+
+@dataclass
+class FeeModel:
+    taker_fee: float = 0.00075
+    slippage_range: tuple[float, float] = (-0.0003, 0.0003)
+    funding_fee: float = 0.0  # placeholder, currently unused
+
+
+def simulate_trade(entry_price: float, direction: str, exit_price: float,
+                   amount: float, leverage: int, fee_model: FeeModel) -> tuple[float, float]:
+    """Return executed exit price and pnl applying slippage and fees."""
+    slip_exit = random.uniform(*fee_model.slippage_range)
+    exec_exit = exit_price * (1 - slip_exit) if direction == "long" else exit_price * (1 + slip_exit)
+
+    size = amount * leverage / entry_price
+    fee = exec_exit * size * fee_model.taker_fee
+
+    gross = calculate_futures_pnl(entry_price, exec_exit, leverage, amount, direction)
+    pnl = gross - fee - fee_model.funding_fee
+
+    return exec_exit, pnl

--- a/trading_gui_core.py
+++ b/trading_gui_core.py
@@ -192,6 +192,12 @@ class TradingGUI(TradingGUILogicMixin):
         self.capital_value.pack(side="left", padx=10)
         self.pnl_value = ttk.Label(top_info, text="📉 PnL: $0", foreground="black", font=("Arial", 11, "bold"))
         self.pnl_value.pack(side="left", padx=10)
+        self.total_pnl_label = ttk.Label(top_info, text="Gesamt PnL: $0", foreground="black", font=("Arial", 11, "bold"))
+        self.total_pnl_label.pack(side="left", padx=10)
+        self.last_trade_label = ttk.Label(top_info, text="Letzter Trade: ---", foreground="blue", font=("Arial", 10))
+        self.last_trade_label.pack(side="left", padx=10)
+        self.trade_count_label = ttk.Label(top_info, text="Trades 0/0", foreground="blue", font=("Arial", 10))
+        self.trade_count_label.pack(side="left", padx=10)
 
         self.api_status_label = ttk.Label(top_info, textvariable=self.api_status_var, foreground="red", font=("Arial", 11, "bold"))
         self.api_status_label.pack(side="left", padx=10)

--- a/trading_gui_logic.py
+++ b/trading_gui_logic.py
@@ -182,6 +182,23 @@ class TradingGUILogicMixin:
         color = "green" if pnl >= 0 else "red"
         self.pnl_value.config(text=f"📉 PnL: {pnl:.2f} $", foreground=color)
 
+    def update_last_trade(self, side: str, entry: float, exit_price: float, pnl: float):
+        text = f"{side.upper()} {entry:.2f}->{exit_price:.2f} ({pnl:.2f}$)"
+        if hasattr(self, "last_trade_label"):
+            self.last_trade_label.config(text=text)
+
+    def update_stats(self, pnl: float):
+        if hasattr(self, "model"):
+            self.model.total_pnl += pnl
+            if pnl >= 0:
+                self.model.wins += 1
+            else:
+                self.model.losses += 1
+            if hasattr(self, "total_pnl_label"):
+                self.total_pnl_label.config(text=f"Gesamt PnL: {self.model.total_pnl:.2f} $")
+            if hasattr(self, "trade_count_label"):
+                self.trade_count_label.config(text=f"Trades {self.model.wins}/{self.model.losses}")
+
     def update_capital(self, capital):
         self.capital_value.config(text=f"💰 Kapital: ${capital:.2f}")
 
@@ -286,6 +303,7 @@ class TradingGUILogicMixin:
 
 
     def update_pnl(self, pnl):
+        self.update_stats(pnl)
         self.log_event(f"💰 Trade abgeschlossen: PnL {pnl:.2f} $")
 
     def log_event(self, msg):


### PR DESCRIPTION
## Summary
- add `simulator.py` with `FeeModel` and `simulate_trade` for slippage and fees
- compute trade entry slippage and taker fees in `realtime_runner`
- track total PnL and trade counts in GUI
- display last trade and stats in GUI

## Testing
- `python -m py_compile simulator.py realtime_runner.py trading_gui_logic.py trading_gui_core.py gui_model.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687579f3bf40832ab1298708fe094afe