### PR TITLE
Implement auto partial close

### DIFF
--- a/exit_handler.py
+++ b/exit_handler.py
@@ -27,3 +27,17 @@ def fetch_open_position() -> Optional[dict]:
     except Exception as exc:
         logger.error("fetch_open_position failed: %s", exc)
         return None
+
+
+def close_partial_position(quantity: float) -> Optional[dict]:
+    """Close part of the current position using a ReduceOnly market order."""
+    try:
+        position = bm.get_open_position()
+        if not position or not position.get("currentQty"):
+            logger.error("close_partial_position failed: no open position")
+            return None
+        side = "SELL" if position["currentQty"] > 0 else "BUY"
+        return bm.place_order(side, quantity, reduce_only=True)
+    except Exception as exc:
+        logger.error("close_partial_position failed: %s", exc)
+        return None


### PR DESCRIPTION
## Summary
- add `close_partial_position` to exit handler to partially close BitMEX positions
- import new function in `realtime_runner`
- auto-close half the position once TP price is reached if enabled
- install websocket-client for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6875d79f98dc832a92b241a664a1bb94