### PR TITLE
Handle soft stop & notify GUI on new trades

### DIFF
--- a/gui_model.py
+++ b/gui_model.py
@@ -14,6 +14,7 @@ class GUIModel:
         # runtime flags
         self.running: bool = False
         self.force_exit: bool = False
+        self.should_stop: bool = False
         self.live_pnl: float = 0.0
         self.total_pnl: float = 0.0
         self.wins: int = 0

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -754,6 +754,8 @@ def _run_bot_live_inner(settings=None, app=None):
                         res = open_position(direction, amount)
                         if res is None:
                             raise RuntimeError("Order placement failed")
+                        if hasattr(app, "send_status_to_gui"):
+                            app.send_status_to_gui("entry_opened", position)
                     except Exception as e:
                         logging.error("Orderplatzierung fehlgeschlagen: %s", e)
             else:
@@ -794,6 +796,11 @@ def _run_bot_live_inner(settings=None, app=None):
         gui_bridge.update_status("✅ Bereit")
 
     while capital > 0 and not getattr(app, "force_exit", False):
+        if getattr(app, "should_stop", False):
+            logging.info("\U0001F6D1 Bot-Stop erkannt – beende Live-Modus.")
+            if hasattr(app, "send_status_to_gui"):
+                app.send_status_to_gui("status", "stopped")
+            return
         if not worker.is_alive():
             worker.start()
         if not getattr(app, "running", False):

--- a/trading_gui_core.py
+++ b/trading_gui_core.py
@@ -392,7 +392,7 @@ class TradingGUI(TradingGUILogicMixin):
         self.trade_box.pack(fill="both", expand=True)
 
     def stop_and_reset(self):
-        self.model.force_exit = True
+        self.model.should_stop = True
         self.model.running = False
         self.log_event("🧹 Bot gestoppt – Keine Rücksetzung der Konfiguration vorgenommen.")
 

--- a/trading_gui_logic.py
+++ b/trading_gui_logic.py
@@ -443,10 +443,10 @@ class TradingGUILogicMixin:
 
 def stop_and_reset(self):
     if hasattr(self, "model"):
-        self.model.force_exit = True
+        self.model.should_stop = True
         self.model.running = False
     else:
-        self.force_exit = True
+        self.should_stop = True
         self.running = False
     try:
         self.log_event("🧹 Bot gestoppt – Keine Rücksetzung der Konfiguration vorgenommen.")


### PR DESCRIPTION
## Summary
- track soft-stop flag in `GUIModel`
- propagate soft stop via `stop_and_reset` methods
- exit bot loop cleanly when GUI sets `should_stop`
- notify GUI on successful entry

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6876088ae2b0832a852f7213c7cdc81c