### PR TITLE
Improve PnL simulation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Dieses Repository folgt drei Prinzipien:
 - 📈 **Realtime-Log**, Systemstatus, und Telegram-Alerts.
 - 🔄 **Auto Partial Close (APC)**: Gewinnmitnahme nach konfigurierbarer PnL-Logik.
 - ✍️ **Manuelle SL/TP-Eingabe** möglich mit Validierung und Statusanzeige.
+- 💸 **Gebührensimulation** und optionaler Partial-Exit im Paper-Modus.
 
 ---
 

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -92,6 +92,8 @@ def handle_existing_position(position, candle, app, capital, live_trading,
         position["amount"],
         position["side"],
     )
+    fee_live = position["amount"] * current * 0.00075
+    pnl_live -= fee_live
 
     if (
         last_printed_pnl is None
@@ -161,6 +163,19 @@ def handle_existing_position(position, candle, app, capital, live_trading,
                 app.log_event(
                     f"⚡ Auto Partial Close bei TP ausgelöst! ➖ {partial_volume} Kontrakte glattgestellt."
                 )
+
+    if (
+        settings.get("simulate_partial", False)
+        and tp_price is not None
+        and position["amount"] > 0
+    ):
+        hit_tp_price = (
+            current >= tp_price if position["side"] == "long" else current <= tp_price
+        )
+        if hit_tp_price:
+            partial_amount = position["amount"] * settings.get("partial_pct", 0.5)
+            logging.info(f"🔄 Simulierter Partial Close: {partial_amount} BTC")
+            position["amount"] -= partial_amount
 
     if hasattr(app, "apc_enabled") and app.apc_enabled.get():
         try:


### PR DESCRIPTION
## Summary
- include trading fee when calculating unrealized PnL
- simulate partial close in paper mode
- document fee simulation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68760d086a4c832a8dc3dd95a499d258