### PR TITLE
Add 10 candle manual entry

### DIFF
--- a/trading_gui_core.py
+++ b/trading_gui_core.py
@@ -237,6 +237,8 @@ class TradingGUI(TradingGUILogicMixin):
 
         from data_provider import init_price_var, price_var
         init_price_var(self.root)
+        self.yolo_button = ttk.Button(top_info, text="🚀 10C Entry", command=self.manual_yolo_entry)
+        self.yolo_button.pack(side="right", padx=5)
         self.price_label = ttk.Label(top_info, textvariable=price_var, foreground="blue", font=("Arial", 11, "bold"))
         self.price_label.pack(side="right", padx=10)
 


### PR DESCRIPTION
## Summary
- support a 10-candle trend entry in the GUI
- add button `🚀 10C Entry` at the top of the interface

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687625e91014832abe93787ada1b7c6b