### PR TITLE
Fix crash from missing GUI filter method

### DIFF
--- a/gui_bridge.py
+++ b/gui_bridge.py
@@ -133,6 +133,7 @@ class GUIBridge:
                 return default
 
         if not self.model:
+            logging.debug("🔁 Dummy update_filter_params aufgerufen (GUIBridge)")
             return
 
         lookback_var = getattr(self.model, "lookback_var", None)

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -269,7 +269,13 @@ def handle_existing_position(position, candle, app, capital, live_trading,
 
     opp_exit = False
     if app:
-        app.update_filter_params()
+        try:
+            if hasattr(app, "update_filter_params"):
+                app.update_filter_params()
+            else:
+                logging.debug("🔁 update_filter_params() nicht verfügbar – übersprungen.")
+        except Exception as e:
+            logging.warning(f"⚠️ update_filter_params() fehlgeschlagen: {e}")
     if signal and signal in ("long", "short"):
         opp_exit = (
             (position["side"] == "long" and signal == "short") or


### PR DESCRIPTION
## Summary
- guard call to `update_filter_params` in `handle_existing_position`
- log dummy call in `GUIBridge.update_filter_params` when no model is attached

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68762ce02a9c832a8e2aeb1baa614dea