### PR TITLE
Add risk & cooldown management extensions

### DIFF
--- a/cooldown_manager.py
+++ b/cooldown_manager.py
@@ -1,24 +1,27 @@
 # cooldown_manager.py
 
 from datetime import datetime, timedelta
+import time
 
 class CooldownManager:
     def __init__(self, cooldown_minutes: int = 3, debug: bool = False):
         self.last_sl_time: datetime | None = None
         self.cooldown_period = timedelta(minutes=cooldown_minutes)
+        self.cooldown_duration = cooldown_minutes * 60
+        self.cooldown_until = 0.0
         self.debug = debug
 
     def register_sl(self, time_of_sl: float):
         self.last_sl_time = datetime.fromtimestamp(time_of_sl)
+        self.cooldown_until = time_of_sl + self.cooldown_duration
         if self.debug:
-            end_time = self.last_sl_time + self.cooldown_period
+            end_time = datetime.fromtimestamp(self.cooldown_until)
             print(f"🔴 Cooldown aktiviert bis: {end_time.strftime('%H:%M:%S')}")
 
     def in_cooldown(self, current_time: float) -> bool:
         if not self.last_sl_time:
             return False
-        now = datetime.fromtimestamp(current_time)
-        active = now < self.last_sl_time + self.cooldown_period
+        active = current_time < self.cooldown_until
         if self.debug:
             remaining = self.get_remaining_seconds(current_time)
             print(f"⏱️ Cooldown aktiv: {remaining}s verbleibend" if active else "🟢 Kein Cooldown")
@@ -27,11 +30,30 @@ class CooldownManager:
     def get_remaining_seconds(self, current_time: float) -> int:
         if not self.last_sl_time:
             return 0
-        remaining = (self.last_sl_time + self.cooldown_period) - datetime.fromtimestamp(current_time)
-        return max(0, int(remaining.total_seconds()))
+        remaining = self.cooldown_until - current_time
+        return max(0, int(remaining))
 
     def reset(self):
         self.last_sl_time = None
+        self.cooldown_until = 0.0
         if self.debug:
             print("🔄 Cooldown zurückgesetzt")
+
+    # ------------------------------------------------------------------
+    # simplified interface used by GUI
+
+    def set_cooldown(self, minutes: int) -> None:
+        self.cooldown_duration = minutes * 60
+        self.cooldown_period = timedelta(minutes=minutes)
+
+    def activate(self) -> None:
+        now = time.time()
+        self.cooldown_until = now + self.cooldown_duration
+        self.last_sl_time = datetime.fromtimestamp(now)
+        if self.debug:
+            end_time = datetime.fromtimestamp(self.cooldown_until)
+            print(f"🔴 Cooldown aktiviert bis: {end_time.strftime('%H:%M:%S')}")
+
+    def is_active(self) -> bool:
+        return time.time() < self.cooldown_until
 


### PR DESCRIPTION
## Summary
- expand `RiskManager` with drawdown tracking, risk checks and helper methods
- extend `CooldownManager` with easier API and time-based tracking
- wire new logic in `realtime_runner` for trade validation and loss handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687649e88924832abf7343e959c5d88c