### PR TITLE
Remove obsolete SL/TP multipliers and show discard reasons

### DIFF
--- a/adaptive_sl_manager.py
+++ b/adaptive_sl_manager.py
@@ -27,21 +27,19 @@ class AdaptiveSLManager:
         return atr
 
 
-    def get_adaptive_sl_tp(self, direction, entry_price, candles, sl_multiplier=0.8, tp_multiplier=1.5):
+    def get_adaptive_sl_tp(self, direction, entry_price, candles):
         direction = direction.lower()
         if direction not in ("long", "short"):
             raise ValueError("Richtung muss 'long' oder 'short' sein.")
 
         atr = self.calculate_atr(candles)
         entry_price = float(entry_price)
-        sl_multiplier = float(sl_multiplier)
-        tp_multiplier = float(tp_multiplier)
 
         if direction == "long":
-            sl = entry_price - atr * sl_multiplier
-            tp = entry_price + atr * tp_multiplier
+            sl = entry_price - atr
+            tp = entry_price + atr
         else:
-            sl = entry_price + atr * sl_multiplier
-            tp = entry_price - atr * tp_multiplier
+            sl = entry_price + atr
+            tp = entry_price - atr
 
-        return round(sl, 2), round(tp, 2)
+        return float(sl), float(tp)

--- a/gui_model.py
+++ b/gui_model.py
@@ -79,6 +79,7 @@ class GUIModel:
         self.sl_tp_auto_active = tk.BooleanVar(master=root, value=False)
         self.sl_tp_manual_active = tk.BooleanVar(master=root, value=False)
         self.sl_tp_status_var = tk.StringVar(master=root, value="")
+        self.last_reason_var = tk.StringVar(master=root, value="–")
 
         # expert settings
         self.volume_factor = tk.StringVar(master=root, value="1.2")

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -573,8 +573,6 @@ def _run_bot_live_inner(settings=None, app=None):
     last_signal = None
     last_signal_time = 0
     entry_repeat_delay = settings.get("entry_repeat_delay", 3)
-    sl_mult = settings["stop_loss_atr_multiplier"]
-    tp_mult = settings["take_profit_atr_multiplier"]
 
     last_printed_pnl = None
     last_printed_price = None
@@ -710,6 +708,8 @@ def _run_bot_live_inner(settings=None, app=None):
             logging.info(msg)
             if hasattr(app, "log_event"):
                 app.log_event(msg)
+            if hasattr(app, "last_reason_var") and andac_signal.reasons:
+                app.last_reason_var.set(f"Verworfen wegen: {andac_signal.reasons[-1]}")
 
         # Timed Exit Logic for simulation mode
         if not live_trading and position_open:
@@ -802,7 +802,7 @@ def _run_bot_live_inner(settings=None, app=None):
                     tp = gui_bridge.manual_tp
                 else:
                     try:
-                        sl, tp = adaptive_sl.get_adaptive_sl_tp(entry_type, entry, candles, tp_multiplier=tp_mult)
+                        sl, tp = adaptive_sl.get_adaptive_sl_tp(entry_type, entry, candles)
                     except Exception as e:
                         logging.error("Adaptive SL Fehler: %s", e)
                         sl = tp = None

--- a/test_sl_tp_logic.py
+++ b/test_sl_tp_logic.py
@@ -7,7 +7,7 @@ class SLTPLogicTest(unittest.TestCase):
         candles = [
             {"high": 105, "low": 95, "close": 100},
         ] * 15
-        sl, tp = manager.get_adaptive_sl_tp("long", 100, candles, sl_multiplier=1, tp_multiplier=2)
+        sl, tp = manager.get_adaptive_sl_tp("long", 100, candles)
         self.assertLess(sl, 100)
         self.assertGreater(tp, 100)
 

--- a/trading_gui_core.py
+++ b/trading_gui_core.py
@@ -185,6 +185,7 @@ class TradingGUI(TradingGUILogicMixin):
         self.sl_tp_auto_active = self.model.sl_tp_auto_active
         self.sl_tp_manual_active = self.model.sl_tp_manual_active
         self.sl_tp_status_var = self.model.sl_tp_status_var
+        self.last_reason_var = self.model.last_reason_var
 
         # expert settings
         self.volume_factor = self.model.volume_factor
@@ -487,6 +488,8 @@ class TradingGUI(TradingGUILogicMixin):
         trade_frame.pack(fill="x", padx=5, pady=(0, 10))
         self.trade_box = tk.Text(trade_frame, height=8, width=85, wrap="word", bg="#f0f0f0", relief="sunken", borderwidth=2, state="disabled")
         self.trade_box.pack(fill="both", expand=True)
+
+        ttk.Label(root, textvariable=self.last_reason_var, foreground="red").pack(pady=(0, 5))
 
     def stop_and_reset(self):
         self.model.should_stop = True


### PR DESCRIPTION
## Summary
- clean up adaptive stop loss manager to drop multipliers and rounding
- expose last signal rejection reason in GUI
- adjust GUI model and core to display the reason label
- update realtime runner to set the label and use new method signature
- fix unit tests for new adaptive SL/TP behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6876bc305ae4832aa3268db4821186bf