### PR TITLE
Enhance EntryMaster controls

### DIFF
--- a/config.py
+++ b/config.py
@@ -26,6 +26,8 @@ SETTINGS = {
     "max_loss": 60,
     "cooldown": 2,
     "cooldown_after_exit": 120,
+    "sl_tp_mode": "adaptive",
+    "opt_session_filter": False,
     "sl_tp_manual_active": True,
     "manual_sl": 0.75,
     "manual_tp": 1.5,

--- a/entry_logic.py
+++ b/entry_logic.py
@@ -1,89 +1,36 @@
-from andac_entry_master import AndacSignal
-import numpy as np
+from andac_entry_master import AndacEntryMaster, AndacSignal
 
-def should_enter(candle, indicator, config) -> AndacSignal:
-    # Candle-Daten
-    close = candle["close"]
-    open_ = candle["open"]
-    high = candle["high"]
-    low = candle["low"]
-    volume = candle["volume"]
+_MASTER: AndacEntryMaster | None = None
 
-    # Parameter & Inputs aus config
-    lookback = config.get("lookback", 20)
-    puffer = config.get("puffer", 10.0)
-    vol_mult = config.get("volumen_factor", 1.2)
-    rsi = indicator.get("rsi", 50)
-    atr = indicator.get("atr", 1)
 
-    # Optionen (GUI)
-    opt_engulf = config.get("opt_engulf", False)
-    opt_engulf_bruch = config.get("opt_engulf_bruch", False)
-    opt_engulf_big = config.get("opt_engulf_big", False)
-    opt_confirm_delay = config.get("opt_confirm_delay", False)
-    opt_mtf_confirm = config.get("opt_mtf_confirm", False)
-    opt_volumen_strong = config.get("opt_volumen_strong", False)
-    opt_rsi_ema = config.get("opt_rsi_ema", False)
-    opt_safe_mode = config.get("opt_safe_mode", False)
-
-    # Zusatzindikatoren
-    mtf_ok = indicator.get("mtf_ok", True)
-    prev_close = indicator.get("prev_close", None)
-    prev_open = indicator.get("prev_open", None)
-    prev_rsi = indicator.get("prev_rsi", None)
-
-    # Candle-Statistik
-    high_prev = indicator.get("high_lookback", high)
-    low_prev = indicator.get("low_lookback", low)
-    avg_vol = indicator.get("avg_volume", volume)
-    prev_bull_signal = indicator.get("prev_bull_signal", False)
-    prev_baer_signal = indicator.get("prev_baer_signal", False)
-
-    # === Signal-Triggerbedingungen
-    bruch_oben = high > high_prev + puffer
-    bruch_unten = low < low_prev - puffer
-    big_candle = abs(close - open_) > atr
-    vol_spike = volume > avg_vol * vol_mult and big_candle
-
-    # === Engulfing
-    bull_engulfing = close > open_ and prev_close < prev_open and close > prev_open and open_ < prev_close
-    baer_engulfing = close < open_ and prev_close > prev_open and close < prev_open and open_ > prev_close
-
-    engulf_long = bull_engulfing and (not opt_engulf_bruch or bruch_oben) and (not opt_engulf_big or big_candle)
-    engulf_short = baer_engulfing and (not opt_engulf_bruch or bruch_unten) and (not opt_engulf_big or big_candle)
-
-    # === Long & Short Grundbedingung
-    long_valid = bruch_oben and vol_spike and (not opt_rsi_ema or rsi > 50) and (not opt_safe_mode or rsi > 30)
-    short_valid = bruch_unten and vol_spike and (not opt_safe_mode or rsi < 70)
-
-    # === Volumenfilter
-    if opt_volumen_strong and not vol_spike:
-        long_valid = short_valid = False
-
-    # === Engulfing-Filter
-    if opt_engulf and not engulf_long:
-        long_valid = False
-    if opt_engulf and not engulf_short:
-        short_valid = False
-
-    # === MTF-Check
-    if opt_mtf_confirm and not mtf_ok:
-        long_valid = short_valid = False
-
-    # === Bestätigungscandle
-    if opt_confirm_delay:
-        long_final = prev_bull_signal and close > open_
-        short_final = prev_baer_signal and close < open_
+def should_enter(candle: dict, indicator: dict, config: dict) -> AndacSignal:
+    global _MASTER
+    if _MASTER is None:
+        _MASTER = AndacEntryMaster(
+            lookback=config.get("lookback", 20),
+            puffer=config.get("puffer", 10.0),
+            vol_mult=config.get("volumen_factor", 1.2),
+            opt_rsi_ema=config.get("opt_rsi_ema", False),
+            opt_safe_mode=config.get("opt_safe_mode", False),
+            opt_engulf=config.get("opt_engulf", False),
+            opt_engulf_bruch=config.get("opt_engulf_bruch", False),
+            opt_engulf_big=config.get("opt_engulf_big", False),
+            opt_confirm_delay=config.get("opt_confirm_delay", False),
+            opt_mtf_confirm=config.get("opt_mtf_confirm", False),
+            opt_volumen_strong=config.get("opt_volumen_strong", False),
+            opt_session_filter=config.get("opt_session_filter", False),
+        )
     else:
-        long_final = long_valid
-        short_final = short_valid
-
-    # === Signal zurückgeben
-    engulf = bull_engulfing if long_final else baer_engulfing if short_final else False
-    if long_final:
-        return AndacSignal(signal="long", rsi=rsi, vol_spike=vol_spike, engulfing=engulf)
-    elif short_final:
-        return AndacSignal(signal="short", rsi=rsi, vol_spike=vol_spike, engulfing=engulf)
-    else:
-        return AndacSignal(signal=None, rsi=rsi, vol_spike=vol_spike, engulfing=engulf, reasons=["No signal conditions met"])
-
+        _MASTER.lookback = config.get("lookback", _MASTER.lookback)
+        _MASTER.puffer = config.get("puffer", _MASTER.puffer)
+        _MASTER.vol_mult = config.get("volumen_factor", _MASTER.vol_mult)
+        _MASTER.opt_rsi_ema = config.get("opt_rsi_ema", _MASTER.opt_rsi_ema)
+        _MASTER.opt_safe_mode = config.get("opt_safe_mode", _MASTER.opt_safe_mode)
+        _MASTER.opt_engulf = config.get("opt_engulf", _MASTER.opt_engulf)
+        _MASTER.opt_engulf_bruch = config.get("opt_engulf_bruch", _MASTER.opt_engulf_bruch)
+        _MASTER.opt_engulf_big = config.get("opt_engulf_big", _MASTER.opt_engulf_big)
+        _MASTER.opt_confirm_delay = config.get("opt_confirm_delay", _MASTER.opt_confirm_delay)
+        _MASTER.opt_mtf_confirm = config.get("opt_mtf_confirm", _MASTER.opt_mtf_confirm)
+        _MASTER.opt_volumen_strong = config.get("opt_volumen_strong", _MASTER.opt_volumen_strong)
+        _MASTER.opt_session_filter = config.get("opt_session_filter", _MASTER.opt_session_filter)
+    return _MASTER.evaluate(candle)

--- a/gui_model.py
+++ b/gui_model.py
@@ -59,7 +59,7 @@ class GUIModel:
         self.andac_opt_confirm_delay = tk.BooleanVar(master=root)
         self.andac_opt_mtf_confirm = tk.BooleanVar(master=root)
         self.andac_opt_volumen_strong = tk.BooleanVar(master=root)
-        # REMOVED: SessionFilter variables
+        self.andac_opt_session_filter = tk.BooleanVar(master=root)
 
         self.use_doji_blocker = tk.BooleanVar(master=root)
 

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -542,6 +542,7 @@ def _run_bot_live_inner(settings=None, app=None):
         "opt_confirm_delay": app.andac_opt_confirm_delay.get(),
         "opt_mtf_confirm": app.andac_opt_mtf_confirm.get(),
         "opt_volumen_strong": app.andac_opt_volumen_strong.get(),
+        "opt_session_filter": app.andac_opt_session_filter.get(),
     }
     from strategy import get_filter_config
     filters = get_filter_config()

--- a/test_entry_logic.py
+++ b/test_entry_logic.py
@@ -1,35 +1,23 @@
 import unittest
-from entry_logic import should_enter
+from entry_logic import should_enter, _MASTER
 
 class EntryLogicTest(unittest.TestCase):
     def test_entry_signal_rsi_engulfing(self):
-        indicator = {
-            "rsi": 55,
-            "atr": 2,
-            "avg_volume": 1100,
-            "high_lookback": 110,
-            "low_lookback": 90,
-            "prev_close": 102,
-            "prev_open": 108,
-            "mtf_ok": True,
-            "prev_bull_signal": False,
-            "prev_baer_signal": False,
-        }
+        global _MASTER
+        _MASTER = None
         config = {
             "lookback": 1,
             "puffer": 1,
             "volumen_factor": 1.2,
             "opt_engulf": True,
-            "opt_engulf_bruch": False,
-            "opt_engulf_big": False,
-            "opt_confirm_delay": False,
-            "opt_mtf_confirm": False,
-            "opt_volumen_strong": False,
-            "opt_safe_mode": False,
-            "opt_rsi_ema": False,
         }
-        candle = {"open":100, "high":112, "low":98, "close":110, "volume":9000}
-        signal = should_enter(candle, indicator, config)
+
+        filler = {"open":100, "high":100, "low":99, "close":100, "volume":1000}
+        prev = {"open":108, "high":110, "low":90, "close":102, "volume":1000}
+        should_enter(filler, {}, config)
+        should_enter(prev, {}, config)
+        candle = {"open":100, "high":112, "low":98, "close":110, "volume":2000}
+        signal = should_enter(candle, {}, config)
         self.assertEqual(signal.signal, "long")
 
 if __name__ == '__main__':

--- a/trading_gui_core.py
+++ b/trading_gui_core.py
@@ -146,7 +146,7 @@ class TradingGUI(TradingGUILogicMixin):
         self.andac_opt_mtf_confirm = self.model.andac_opt_mtf_confirm
         self.andac_opt_volumen_strong = self.model.andac_opt_volumen_strong
 
-        # REMOVED: SessionFilter variables
+        self.andac_opt_session_filter = self.model.andac_opt_session_filter
 
         self.use_doji_blocker = self.model.use_doji_blocker
 
@@ -423,16 +423,16 @@ class TradingGUI(TradingGUILogicMixin):
             ("Engulfing", self.andac_opt_engulf),
             ("Engulfing + Breakout", self.andac_opt_engulf_bruch),
             ("Engulfing > ATR", self.andac_opt_engulf_big),
-            ("Bestätigungskerze", self.andac_opt_confirm_delay),
+            ("Bestätigungskerze (Delay)", self.andac_opt_confirm_delay),
             ("MTF Bestätigung", self.andac_opt_mtf_confirm),
             ("Starkes Volumen", self.andac_opt_volumen_strong),
+            ("Session 7-20 UTC", self.andac_opt_session_filter),
         ]:
             ttk.Checkbutton(left_col, text=text, variable=var).pack(anchor="w")
 
         self._add_entry_group(right_col, "Lookback", [self.andac_lookback])
         self._add_entry_group(right_col, "Toleranz", [self.andac_puffer])
         self._add_entry_group(right_col, "Volumen-Faktor", [self.andac_vol_mult])
-        # REMOVED: SessionFilter GUI elements
 
     def _build_expert_options(self, parent):
         ttk.Label(parent, text="⚙️ Experteneinstellungen", font=("Arial", 11, "bold")).pack(pady=(0, 5))

--- a/trading_gui_logic.py
+++ b/trading_gui_logic.py
@@ -43,6 +43,7 @@ class TradingGUILogicMixin:
                 self.andac_opt_confirm_delay,
                 self.andac_opt_mtf_confirm,
                 self.andac_opt_volumen_strong,
+                self.andac_opt_session_filter,
                 self.use_doji_blocker,
                 self.use_time_filter,
             ]
@@ -93,6 +94,7 @@ class TradingGUILogicMixin:
                 "opt_confirm_delay": self.andac_opt_confirm_delay.get(),
                 "opt_mtf_confirm": self.andac_opt_mtf_confirm.get(),
                 "opt_volumen_strong": self.andac_opt_volumen_strong.get(),
+                "opt_session_filter": self.andac_opt_session_filter.get(),
             })
 
             self.log_event("✅ Auto-Empfehlungen angewendet")
@@ -110,6 +112,7 @@ class TradingGUILogicMixin:
                 self.andac_opt_confirm_delay,
                 self.andac_opt_mtf_confirm,
                 self.andac_opt_volumen_strong,
+                self.andac_opt_session_filter,
                 self.use_time_filter,
                 self.use_doji_blocker,
             ]:
@@ -191,6 +194,7 @@ class TradingGUILogicMixin:
                 "sl_tp_mode": sl_tp_mode,
                 "max_trades_hour": max_trades_hour,
                 "fee_percent": fee_percent,
+                "opt_session_filter": self.andac_opt_session_filter.get(),
             }
         )
 
@@ -203,6 +207,7 @@ class TradingGUILogicMixin:
             "use_rsi": self.use_rsi.get(),
             "use_macd": self.use_macd.get(),
             "sl_mode": sl_tp_mode,
+            "opt_session_filter": self.andac_opt_session_filter.get(),
         }
         try:
             from strategy import set_filter_config


### PR DESCRIPTION
## Summary
- rely on `AndacEntryMaster` for signal evaluation
- expose session filter option in the GUI model and interface
- persist session filter setting in config and strategy startup
- show more detailed confirmation delay text in GUI
- update tests for revised entry logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6876c27bb044832a8fdbeab35875df54