### PR TITLE
Remove unused volume filter hook

### DIFF
--- a/gui_bridge.py
+++ b/gui_bridge.py
@@ -153,13 +153,11 @@ class GUIBridge:
 
         lookback_var = getattr(self.model, "lookback_var", None)
         toleranz_var = getattr(self.model, "toleranz_var", None)
-        volume_var = getattr(self.model, "volume_var", None)
         breakout_var = getattr(self.model, "breakout_var", None)
 
         SETTINGS.update({
             "lookback": get_safe_int(lookback_var, 3),
             "toleranz": get_safe_float(toleranz_var, 0.01),
-            "min_volume": get_safe_float(volume_var, 0.0),
             "breakout_only": breakout_var.get() if breakout_var else False,
         })
 

--- a/trading_gui_core.py
+++ b/trading_gui_core.py
@@ -95,7 +95,6 @@ class TradingGUI(TradingGUILogicMixin):
             "auto_rec": ("Auto Empfehlungen", self.auto_apply_recommendations),
             "auto_multi": ("Auto Multiplikator", self.auto_multiplier),
             "safe": ("Sicherheitsfilter", self.andac_opt_safe_mode),
-            "vol": ("Volumenfilter", self.andac_opt_volumen_strong),
             "paper": ("Paper-Trading aktiv", self.paper_mode),
             "saved": ("Konfiguration gespeichert", None),
         }


### PR DESCRIPTION
## Summary
- clean up Neon panel status mapping
- drop leftover volume settings from GUI bridge

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6876cedc2418832a821a286d50202139