### PR TITLE
Improve expert tab visibility

### DIFF
--- a/trading_gui_core.py
+++ b/trading_gui_core.py
@@ -76,9 +76,9 @@ class TradingGUI(TradingGUILogicMixin):
 
         self.root.update_idletasks()
         width = self.root.winfo_width()
-        height = int(self.root.winfo_height() * 0.9) - 30
+        height = int(self.root.winfo_height() * 0.8) - 30
         if height < 200:
-            height = int(self.root.winfo_height() * 0.9)
+            height = int(self.root.winfo_height() * 0.8)
         self.root.geometry(f"{width}x{height}")
 
         self.update_trade_display()
@@ -265,6 +265,7 @@ class TradingGUI(TradingGUILogicMixin):
         expert_container = ttk.Frame(notebook)
         notebook.add(container, text="Einstellungen")
         notebook.add(expert_container, text="Experteneinstellungen")
+        notebook.select(expert_container)
         risk = ttk.Frame(container)
         left = ttk.Frame(container)
         right = ttk.Frame(container)


### PR DESCRIPTION
## Summary
- select expert tab by default in the GUI
- reduce default window height by an additional 10%

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6876d33584bc832aaa5d766b46773801