### PR TITLE
Implement GUI export with widget registry

### DIFF
--- a/gui_registry.py
+++ b/gui_registry.py
@@ -1,0 +1,45 @@
+# gui_registry.py
+"""Registry utilities to track Tkinter widgets for export."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+registered_elements: list[dict[str, Any]] = []
+
+
+def register_element(widget: Any, name: str, var: Any | None = None, command: Callable | None = None) -> None:
+    """Register a widget with optional variable and command."""
+    registered_elements.append({
+        "widget": widget,
+        "name": name,
+        "var": var,
+        "command": command,
+    })
+
+
+def export_gui(path: str = "gui_export.json") -> None:
+    """Export information about all registered widgets to JSON."""
+    elements = []
+    for item in registered_elements:
+        widget = item.get("widget")
+        name = item.get("name")
+        var = item.get("var")
+        command = item.get("command")
+        value = None
+        if var is not None:
+            try:
+                value = var.get()
+            except Exception:
+                value = None
+        elements.append({
+            "name": name,
+            "type": type(widget).__name__ if widget is not None else None,
+            "has_logic": command is not None,
+            "value": value,
+        })
+
+    Path(path).write_text(json.dumps(elements, indent=2, ensure_ascii=False), encoding="utf-8")
+

--- a/trading_gui_core.py
+++ b/trading_gui_core.py
@@ -11,6 +11,7 @@ from api_credential_frame import APICredentialFrame, EXCHANGES
 from neon_status_panel import NeonStatusPanel
 from api_key_manager import APICredentialManager
 from status_events import StatusDispatcher
+from gui_registry import register_element
 
 class TradingGUI(TradingGUILogicMixin):
     def __getattr__(self, item):
@@ -82,6 +83,16 @@ class TradingGUI(TradingGUILogicMixin):
         self.root.geometry(f"{width}x{height}")
 
         self.update_trade_display()
+
+    def export_gui(self) -> None:
+        """Create a JSON export of all registered GUI elements."""
+        from gui_registry import export_gui
+
+        try:
+            export_gui()
+            self.log_event("📋 GUI-Export gespeichert")
+        except Exception as exc:
+            self.log_event(f"❌ GUI-Export fehlgeschlagen: {exc}")
 
     def _init_neon_panel(self):
         self.neon_panel = NeonStatusPanel(self.root)
@@ -447,24 +458,41 @@ class TradingGUI(TradingGUILogicMixin):
         button_frame = ttk.Frame(root)
         button_frame.pack(pady=10, fill="x")
 
-        ttk.Button(button_frame, text="▶️ Bot starten", command=self.start_bot).grid(row=0, column=0, padx=5)
+        start_btn = ttk.Button(button_frame, text="▶️ Bot starten", command=self.start_bot)
+        start_btn.grid(row=0, column=0, padx=5)
+        register_element(start_btn, "start_button", command=self.start_bot)
         ttk.Button(button_frame, text="⛔ Trade abbrechen", command=self.emergency_flat_position).grid(row=0, column=1, padx=5)
         ttk.Button(button_frame, text="❗️ Notausstieg", command=self.emergency_exit).grid(row=0, column=2, padx=5)
         ttk.Button(button_frame, text="🛑 Alles stoppen & sichern", command=self.stop_and_reset).grid(row=0, column=3, padx=5)
 
-        ttk.Checkbutton(
+        auto_chk = ttk.Checkbutton(
             button_frame,
             text="🔁 Auto-Empfehlungen",
             variable=self.auto_apply_recommendations,
             command=self.update_auto_status,
-        ).grid(row=1, column=0, padx=5)
-        ttk.Button(button_frame, text="✅ Empfehlungen übernehmen", command=self.apply_recommendations).grid(row=1, column=1, padx=5)
-        ttk.Button(button_frame, text="🧹 Alles deaktivieren", command=self.disable_all_filters).grid(row=1, column=2, padx=5)
-        ttk.Button(button_frame, text="💾 Einstellungen speichern", command=self.save_to_file).grid(row=1, column=3, padx=5)
-        ttk.Button(button_frame, text="⏏️ Einstellungen laden", command=self.load_from_file).grid(row=1, column=4, padx=5)
+        )
+        auto_chk.grid(row=1, column=0, padx=5)
+        register_element(auto_chk, "auto_recommendations_chk", var=self.auto_apply_recommendations, command=self.update_auto_status)
+        apply_btn = ttk.Button(button_frame, text="✅ Empfehlungen übernehmen", command=self.apply_recommendations)
+        apply_btn.grid(row=1, column=1, padx=5)
+        register_element(apply_btn, "apply_recommendations_button", command=self.apply_recommendations)
+        disable_btn = ttk.Button(button_frame, text="🧹 Alles deaktivieren", command=self.disable_all_filters)
+        disable_btn.grid(row=1, column=2, padx=5)
+        register_element(disable_btn, "disable_filters_button", command=self.disable_all_filters)
+
+        save_btn = ttk.Button(button_frame, text="💾 Einstellungen speichern", command=self.save_to_file)
+        save_btn.grid(row=1, column=3, padx=5)
+        register_element(save_btn, "save_settings_button", command=self.save_to_file)
+
+        load_btn = ttk.Button(button_frame, text="⏏️ Einstellungen laden", command=self.load_from_file)
+        load_btn.grid(row=1, column=4, padx=5)
+        register_element(load_btn, "load_settings_button", command=self.load_from_file)
+        export_btn = ttk.Button(button_frame, text="\U0001F4CB GUI-Export erstellen", command=self.export_gui)
+        export_btn.grid(row=1, column=5, padx=5)
+        register_element(export_btn, "export_button", command=self.export_gui)
 
         self.auto_status_label = ttk.Label(button_frame, font=("Arial", 10, "bold"), foreground="green")
-        self.auto_status_label.grid(row=2, column=0, columnspan=5, pady=(5, 0), padx=10, sticky="w")
+        self.auto_status_label.grid(row=2, column=0, columnspan=6, pady=(5, 0), padx=10, sticky="w")
 
         self.log_box = tk.Text(root, height=13, width=85, wrap="word", bg="#f9f9f9", relief="sunken", borderwidth=2)
         self.log_box.pack(pady=12)


### PR DESCRIPTION
## Summary
- create `gui_registry` module with central widget registration and export
- register key control widgets in `TradingGUI`
- add export button to create `gui_export.json`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6876dc4665e8832ab2d1570a54988b67