### PR TITLE
Remove old imports and use unified entry logic

### DIFF
--- a/api_credential_frame.py
+++ b/api_credential_frame.py
@@ -5,7 +5,8 @@ from typing import Dict
 
 from api_key_manager import APICredentialManager
 from status_events import StatusDispatcher
-from config import SETTINGS
+# Access bot settings from the consolidated module
+from andac_entry_master import SETTINGS
 from bitmex_interface import set_credentials, check_credentials
 
 EXCHANGES = ["BitMEX"]

--- a/config_manager.py
+++ b/config_manager.py
@@ -6,7 +6,9 @@ import os
 import logging
 from typing import Any, Dict
 
-from config import SETTINGS as DEFAULTS
+# SETTINGS was previously defined in config.py which has been removed.
+# Import defaults from the consolidated logic module instead.
+from andac_entry_master import SETTINGS as DEFAULTS
 
 
 class ConfigManager:

--- a/data_provider.py
+++ b/data_provider.py
@@ -8,16 +8,16 @@ import time
 import threading
 import queue
 
-import binance_ws
+# Import consolidated WebSocket implementation and settings
+from andac_entry_master import BinanceCandleWebSocket, BINANCE_SYMBOL, BINANCE_INTERVAL
 from tkinter import Tk, StringVar
-from config import BINANCE_SYMBOL, BINANCE_INTERVAL
 import requests
 from status_events import StatusDispatcher
 from config_manager import config
 
 logger = logging.getLogger(__name__)
 
-_CANDLE_WS_CLIENT: binance_ws.BinanceCandleWebSocket | None = None
+_CANDLE_WS_CLIENT: BinanceCandleWebSocket | None = None
 _WS_CANDLES: list[Candle] = []
 _CANDLE_LOCK = threading.Lock()
 _CANDLE_QUEUE: queue.Queue[Candle] = queue.Queue(maxsize=100)
@@ -134,7 +134,7 @@ def start_candle_websocket(interval: str | None = None) -> None:
         raise RuntimeError("Initial candle download failed")
 
     logger.info("WebSocket Candle-Stream gestartet")
-    _CANDLE_WS_CLIENT = binance_ws.BinanceCandleWebSocket(
+    _CANDLE_WS_CLIENT = BinanceCandleWebSocket(
         update_candle_feed,
         interval=interval,
     )
@@ -248,7 +248,12 @@ def stop_feed_monitor() -> None:
         _FEED_MONITOR_THREAD = None
 
 def get_last_candle_time() -> Optional[float]:
-    return binance_ws.last_candle_time
+    """Return timestamp of the latest received candle from the WebSocket."""
+    try:
+        import global_state
+        return global_state.last_candle_ts
+    except Exception:
+        return None
 
 
 

--- a/gui_bridge.py
+++ b/gui_bridge.py
@@ -1,6 +1,7 @@
 # gui_bridge.py
 
-from config import SETTINGS
+# Bridge to interact with configuration stored in andac_entry_master
+from andac_entry_master import SETTINGS
 
 def smart_auto_multiplier(score, atr, balance, drawdown, max_risk_pct=1.0, base_multi=20, min_multi=1, max_multi=50):
     """Return a leverage suggestion based on score, ATR and drawdown."""

--- a/main.py
+++ b/main.py
@@ -10,9 +10,9 @@ import tkinter as tk
 from colorama import Fore, Style, init
 from central_logger import setup_logging
 
-from config import SETTINGS
+# SETTINGS and helper classes consolidated in andac_entry_master
+from andac_entry_master import SETTINGS, AutoRecommender
 from config_manager import config
-from auto_recommender import AutoRecommender
 from system_monitor import SystemMonitor
 from trading_gui_core import TradingGUI
 from trading_gui_logic import TradingGUILogicMixin

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -28,15 +28,19 @@ from data_provider import (
     start_candle_websocket,
     get_candle_queue,
 )
-from config import BINANCE_INTERVAL, BINANCE_SYMBOL
-from entry_handler import open_position
-from exit_handler import close_position, close_partial_position as api_close_partial_position
-from cooldown_manager import CooldownManager
+from andac_entry_master import (
+    BINANCE_INTERVAL,
+    BINANCE_SYMBOL,
+    open_position,
+    close_position,
+    close_partial_position as api_close_partial_position,
+    CooldownManager,
+)
 from status_block import print_entry_status
 from gui_bridge import GUIBridge
 from trading_gui_core import TradingGUI
 from trading_gui_logic import TradingGUILogicMixin
-from config import SETTINGS
+from andac_entry_master import SETTINGS
 from central_logger import log_triangle_signal
 from global_state import (
     entry_time_global,
@@ -46,16 +50,14 @@ from global_state import (
 )
 import global_state
 
-from indicator_utils import (
+from andac_entry_master import (
     calculate_ema,
     calculate_atr,
     macd_crossover_detected,
 )
 
 from andac_entry_master import AndacEntryMaster, AndacSignal
-from signal_worker import SignalWorker
-from entry_logic import should_enter
-from adaptive_sl_manager import AdaptiveSLManager
+from andac_entry_master import SignalWorker, should_enter, AdaptiveSLManager
 from status_events import StatusDispatcher
 
 
@@ -368,7 +370,7 @@ def handle_existing_position(position, candle, app, capital, live_trading,
 
     return position, capital, last_printed_pnl, last_printed_price, False
 
-from risk_manager import RiskManager
+from andac_entry_master import RiskManager
 from console_status import (
     print_start_banner,
     print_stop_banner,

--- a/trading_gui_core.py
+++ b/trading_gui_core.py
@@ -67,7 +67,8 @@ class TradingGUI(TradingGUILogicMixin):
         StatusDispatcher.on_feed_status(self.update_feed_status)
 
 
-        from config import SETTINGS
+        # SETTINGS now resides in andac_entry_master
+        from andac_entry_master import SETTINGS
         SETTINGS["data_source_mode"] = "websocket"
         self.model.websocket_active = True
         self._update_feed_mode_display(False)
@@ -630,7 +631,8 @@ class TradingGUI(TradingGUILogicMixin):
             self.api_frame.system_status_label.config(foreground=color)
 
     def _update_market_monitor(self) -> None:
-        from config import BINANCE_SYMBOL
+        # BINANCE_SYMBOL constant moved to andac_entry_master
+        from andac_entry_master import BINANCE_SYMBOL
         from data_provider import fetch_last_price, WebSocketStatus
 
         symbol = BINANCE_SYMBOL

--- a/trading_gui_logic.py
+++ b/trading_gui_logic.py
@@ -14,7 +14,8 @@ class TradingGUILogicMixin:
         try:
             from datetime import datetime
             from global_state import ema_trend_global, atr_value_global
-            from config import SETTINGS
+            # SETTINGS moved to andac_entry_master
+            from andac_entry_master import SETTINGS
 
             volatility = atr_value_global
             if volatility is None:
@@ -174,7 +175,8 @@ class TradingGUILogicMixin:
                 drawdown_pct,
                 cooldown,
             )
-        from config import SETTINGS
+        # SETTINGS has been relocated
+        from andac_entry_master import SETTINGS
         SETTINGS.update(
             {
                 "risk_per_trade": risk_pct,
@@ -197,7 +199,8 @@ class TradingGUILogicMixin:
             "opt_session_filter": self.andac_opt_session_filter.get(),
         }
         try:
-            from strategy import set_filter_config
+            # Filter configuration helper is now bundled in andac_entry_master
+            from andac_entry_master import set_filter_config
             set_filter_config(filters)
         except Exception:
             pass
@@ -240,7 +243,7 @@ class TradingGUILogicMixin:
             self.running = False
 
     def manual_yolo_entry(self):
-        from config import SETTINGS
+        from andac_entry_master import SETTINGS
         from data_provider import get_live_candles, fetch_last_price
         from realtime_runner import simulate_trade
         from tkinter import messagebox
@@ -287,7 +290,7 @@ class TradingGUILogicMixin:
             SETTINGS["capital"] = simulate_trade(position, price, current_index, SETTINGS, capital)
             self.update_capital(SETTINGS["capital"])
         else:
-            from entry_handler import open_position
+            from andac_entry_master import open_position
             res = open_position("BUY" if direction == "long" else "SELL", amount)
             if not res:
                 messagebox.showerror("Fehlgeschlagen", "Live-Order konnte nicht gesendet werden.")
@@ -518,7 +521,7 @@ class TradingGUILogicMixin:
         self.log_event(f"📝 Manuelles SL/TP {state}")
 
     def update_manual_sl_tp_status(self):
-        from config import SETTINGS
+        from andac_entry_master import SETTINGS
 
         if self.sl_tp_manual_active.get():
             if hasattr(self, "toggle_sl_tp_button"):
@@ -539,7 +542,7 @@ class TradingGUILogicMixin:
             self.sl_tp_status_var.set(msg)
 
     def save_manual_sl(self):
-        from config import SETTINGS
+        from andac_entry_master import SETTINGS
 
         try:
             sl = float(self.manual_sl_var.get())
@@ -554,7 +557,7 @@ class TradingGUILogicMixin:
             )
 
     def save_manual_tp(self):
-        from config import SETTINGS
+        from andac_entry_master import SETTINGS
 
         try:
             tp = float(self.manual_tp_var.get())


### PR DESCRIPTION
## Summary
- use settings and classes from `andac_entry_master.py`
- update GUI modules to rely on consolidated defaults
- refactor data provider to use built-in Binance websocket
- clean up realtime runner imports
- adjust config manager to use unified settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68770a14cb90832a880a35d5c398d01a