### PR TITLE
Remove CooldownManager usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,6 @@ EntryMaster_Tradingview/
 ├── central_logger.py
 ├── config.py
 ├── console_status.py
-├── cooldown_manager.py
 ├── data_provider.py
 ├── global_state.py
 ├── gui_bridge.py

--- a/andac_entry_master.py
+++ b/andac_entry_master.py
@@ -352,26 +352,6 @@ class AdaptiveSLManager:
         return float(sl), float(tp)
 
 
-# ---------------------------------------------------------------------------
-# CooldownManager (from cooldown_manager.py)
-class CooldownManager:
-    def __init__(self, cooldown_minutes: int = 3, debug: bool = False) -> None:
-        self.cooldown_duration = cooldown_minutes * 60
-        self.cooldown_until = 0.0
-        self.debug = debug
-
-    def register_sl(self, time_of_sl: float) -> None:
-        self.cooldown_until = time_of_sl + self.cooldown_duration
-        if self.debug:
-            end_time = datetime.fromtimestamp(self.cooldown_until)
-            print(f"\uD83D\uDD34 Cooldown aktiviert bis: {end_time.strftime('%H:%M:%S')}")
-
-    def in_cooldown(self, current_time: float) -> bool:
-        return current_time < self.cooldown_until
-
-    def reset(self) -> None:
-        self.cooldown_until = 0.0
-
 
 # ---------------------------------------------------------------------------
 # Entry/Exit handler wrappers (from entry_handler.py & exit_handler.py)


### PR DESCRIPTION
## Summary
- delete CooldownManager class from `andac_entry_master.py`
- drop cooldown imports and logic in `realtime_runner.py`
- update README to remove reference to the removed module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68771b3caccc832a94319c754427e41a