### PR TITLE
Fix None handling for SL and TP logging

### DIFF
--- a/entrymaster_combined.py
+++ b/entrymaster_combined.py
@@ -3960,12 +3960,22 @@ def handle_existing_position(position, candle, app, capital, live_trading,
             entry,
             current,
         )
-        logging.info(
-            "🎯 SL: %.2f | TP: %.2f | PnL: %.2f",
-            position["sl"],
-            position["tp"],
-            pnl_live,
-        )
+        sl_val = position.get("sl")
+        tp_val = position.get("tp")
+        if sl_val is not None and tp_val is not None:
+            logging.info(
+                "🎯 SL: %.2f | TP: %.2f | PnL: %.2f",
+                sl_val,
+                tp_val,
+                pnl_live,
+            )
+        else:
+            logging.warning(
+                "🎯 SL oder TP nicht gesetzt – SL: %s | TP: %s | PnL: %.2f",
+                str(sl_val) if sl_val is not None else "None",
+                str(tp_val) if tp_val is not None else "None",
+                pnl_live,
+            )
         last_printed_pnl = pnl_live
         last_printed_price = current
 

--- a/entrymaster_final_deduped_clean.py
+++ b/entrymaster_final_deduped_clean.py
@@ -4063,12 +4063,22 @@ def handle_existing_position(position, candle, app, capital, live_trading,
             entry,
             current,
         )
-        logging.info(
-            "🎯 SL: %.2f | TP: %.2f | PnL: %.2f",
-            position["sl"],
-            position["tp"],
-            pnl_live,
-        )
+        sl_val = position.get("sl")
+        tp_val = position.get("tp")
+        if sl_val is not None and tp_val is not None:
+            logging.info(
+                "🎯 SL: %.2f | TP: %.2f | PnL: %.2f",
+                sl_val,
+                tp_val,
+                pnl_live,
+            )
+        else:
+            logging.warning(
+                "🎯 SL oder TP nicht gesetzt – SL: %s | TP: %s | PnL: %.2f",
+                str(sl_val) if sl_val is not None else "None",
+                str(tp_val) if tp_val is not None else "None",
+                pnl_live,
+            )
         last_printed_pnl = pnl_live
         last_printed_price = current
 

--- a/realtime_runner.py
+++ b/realtime_runner.py
@@ -105,12 +105,22 @@ def handle_existing_position(position, candle, app, capital, live_trading,
             entry,
             current,
         )
-        logging.info(
-            "🎯 SL: %.2f | TP: %.2f | PnL: %.2f",
-            position["sl"],
-            position["tp"],
-            pnl_live,
-        )
+        sl_val = position.get("sl")
+        tp_val = position.get("tp")
+        if sl_val is not None and tp_val is not None:
+            logging.info(
+                "🎯 SL: %.2f | TP: %.2f | PnL: %.2f",
+                sl_val,
+                tp_val,
+                pnl_live,
+            )
+        else:
+            logging.warning(
+                "🎯 SL oder TP nicht gesetzt – SL: %s | TP: %s | PnL: %.2f",
+                str(sl_val) if sl_val is not None else "None",
+                str(tp_val) if tp_val is not None else "None",
+                pnl_live,
+            )
         last_printed_pnl = pnl_live
         last_printed_price = current
 


### PR DESCRIPTION
## Summary
- handle None values for stop-loss and take-profit when logging open positions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68777137b7c4832ab1c59e8331c6202f