### PR TITLE
Fix cancel button and add timed exit when SL/TP missing

### DIFF
--- a/trading_gui_logic.py
+++ b/trading_gui_logic.py
@@ -5,6 +5,7 @@ import os
 import tkinter as tk
 from tkinter import messagebox
 from datetime import datetime
+from realtime_runner import cancel_trade
 
 TUNING_FILE = "tuning_config.json"
 


### PR DESCRIPTION
## Summary
- import `cancel_trade` in GUI logic
- handle missing SL/TP in `handle_existing_position` with timed exit after MAX_HOLD_CANDLES

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68777d003094832a9aa61240b06deae3