### PR TITLE
Fix circular import in TradingGUI

### DIFF
--- a/trading_gui_logic.py
+++ b/trading_gui_logic.py
@@ -5,7 +5,6 @@ import os
 import tkinter as tk
 from tkinter import messagebox
 from datetime import datetime
-from realtime_runner import cancel_trade
 
 TUNING_FILE = "tuning_config.json"
 
@@ -164,8 +163,9 @@ class TradingGUILogicMixin:
             self.force_exit = True
             self.running = False
         self.log_event("⛔ Trade abbrechen: Die Position wird jetzt geschlossen.")
-        
+
         if hasattr(self, 'position') and self.position is not None:
+            from realtime_runner import cancel_trade
             self.position = cancel_trade(self.position, self)
             self.log_event("✅ Position wurde erfolgreich geschlossen.")
         else:


### PR DESCRIPTION
## Summary
- remove early import of `cancel_trade` in `trading_gui_logic`
- lazy load `cancel_trade` inside `emergency_flat_position`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68777f55b630832ab2ab1e29b989c75b