### PR TITLE
Add position cleanup verification

### DIFF
--- a/entrymaster_combined.py
+++ b/entrymaster_combined.py
@@ -1243,6 +1243,10 @@ class TradingGUILogicMixin:
         
         if hasattr(self, 'position') and self.position is not None:
             self.position = cancel_trade(self.position, self)
+            if self.position is None:
+                logging.info("✅ Position wurde erfolgreich geschlossen und gel\u00f6scht.")
+            else:
+                logging.warning("\u26a0\ufe0f Position konnte nicht vollst\u00e4ndig entfernt werden.")
             self.log_event("✅ Position wurde erfolgreich geschlossen.")
         else:
             self.log_event("❌ Keine offene Position zum Abbrechen gefunden.")

--- a/entrymaster_final_deduped_clean.py
+++ b/entrymaster_final_deduped_clean.py
@@ -1,4 +1,7 @@
 
+# Needed for runtime logging
+import logging
+
 # === Dummy-Ersatz für Objekte aus andac_entry_master.py ===
 BINANCE_SYMBOL = "btcusdt"
 BINANCE_INTERVAL = "1m"
@@ -1184,6 +1187,10 @@ TUNING_FILE = "tuning_config.json"
         
         if hasattr(self, 'position') and self.position is not None:
             self.position = cancel_trade(self.position, self)
+            if self.position is None:
+                logging.info("✅ Position wurde erfolgreich geschlossen und gel\u00f6scht.")
+            else:
+                logging.warning("\u26a0\ufe0f Position konnte nicht vollst\u00e4ndig entfernt werden.")
             self.log_event("✅ Position wurde erfolgreich geschlossen.")
         else:
             self.log_event("❌ Keine offene Position zum Abbrechen gefunden.")
@@ -5771,6 +5778,10 @@ class TradingGUILogicMixin:
         
         if hasattr(self, 'position') and self.position is not None:
             self.position = cancel_trade(self.position, self)
+            if self.position is None:
+                logging.info("✅ Position wurde erfolgreich geschlossen und gel\u00f6scht.")
+            else:
+                logging.warning("\u26a0\ufe0f Position konnte nicht vollst\u00e4ndig entfernt werden.")
             self.log_event("✅ Position wurde erfolgreich geschlossen.")
         else:
             self.log_event("❌ Keine offene Position zum Abbrechen gefunden.")

--- a/trading_gui_logic.py
+++ b/trading_gui_logic.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import logging
 import tkinter as tk
 from tkinter import messagebox
 from datetime import datetime
@@ -167,6 +168,10 @@ class TradingGUILogicMixin:
         if hasattr(self, 'position') and self.position is not None:
             from realtime_runner import cancel_trade
             self.position = cancel_trade(self.position, self)
+            if self.position is None:
+                logging.info("✅ Position wurde erfolgreich geschlossen und gel\u00f6scht.")
+            else:
+                logging.warning("\u26a0\ufe0f Position konnte nicht vollst\u00e4ndig entfernt werden.")
             self.log_event("✅ Position wurde erfolgreich geschlossen.")
         else:
             self.log_event("❌ Keine offene Position zum Abbrechen gefunden.")


### PR DESCRIPTION
## Summary
- add `logging` dependency in trading_gui_logic module
- ensure `cancel_trade` clears position properly with added log output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687792251a60832a8e41e4ec99127f2e